### PR TITLE
fix(compiler): tolerate blocked ledger symbols absent from older toolchains

### DIFF
--- a/compiler/override-parity-verifier.go
+++ b/compiler/override-parity-verifier.go
@@ -207,14 +207,33 @@ func verifyOverrideParityPackage(
 		}
 	}
 	for symbol := range ledger.Symbols {
-		if !goExportSet[symbol] {
+		if goExportSet[symbol] {
+			continue
+		}
+		// Cross-toolchain superset rule: a blocked entry may outlive the
+		// toolchain that exported its symbol. When this toolchain lacks the
+		// export and TypeScript does not provide one either, there is nothing
+		// to verify. A TypeScript export standing in for a blocked symbol
+		// stays an error, and every other status still rejects the row.
+		entry := ledger.Symbols[symbol]
+		if entry.Status == overrideParityStatusBlocked && !tsExports[symbol].present() {
+			continue
+		}
+		if entry.Status.forbidsExport() && tsExports[symbol].present() {
 			diagnostics = append(diagnostics, Diagnostic{
 				Severity: DiagnosticSeverityError,
-				Code:     "goscript/overrides:parity-unknown-symbol",
-				Message:  "override parity ledger references a symbol not exported by the Go package",
-				Detail:   pkgPath + "." + symbol,
+				Code:     "goscript/overrides:parity-unexpected-export",
+				Message:  "override parity ledger marks a Go export blocked, but TypeScript exports it",
+				Detail:   pkgPath + "." + symbol + " is classified as " + string(entry.Status),
 			})
+			continue
 		}
+		diagnostics = append(diagnostics, Diagnostic{
+			Severity: DiagnosticSeverityError,
+			Code:     "goscript/overrides:parity-unknown-symbol",
+			Message:  "override parity ledger references a symbol not exported by the Go package",
+			Detail:   pkgPath + "." + symbol,
+		})
 	}
 	return diagnostics
 }

--- a/compiler/override-parity-verifier_test.go
+++ b/compiler/override-parity-verifier_test.go
@@ -2,6 +2,8 @@ package compiler
 
 import (
 	"context"
+	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -97,4 +99,54 @@ func requireDiagnosticSeverity(t *testing.T, diagnostics []Diagnostic, code stri
 		}
 	}
 	t.Fatalf("missing diagnostic %q with severity %q in %#v", code, severity, diagnostics)
+}
+
+func TestOverrideParityVerifierBlockedToolchainSuperset(t *testing.T) {
+	pkg := types.NewPackage("example.test/future", "future")
+	ledger := overrideParityLedger{
+		SchemaVersion: 1,
+		Strict:        true,
+		Symbols: map[string]overrideParityEntry{
+			"FutureBlocked": {Status: overrideParityStatusBlocked, Reason: "newer stdlib surface"},
+			"FutureReal":    {Status: overrideParityStatusReal},
+		},
+	}
+
+	t.Run("blocked absent from go and typescript passes", func(t *testing.T) {
+		diagnostics := verifyOverrideParityPackage(pkg.Path(), pkg, ledger, nil, nil)
+		for _, diagnostic := range diagnostics {
+			if diagnostic.Code == "goscript/overrides:parity-unknown-symbol" &&
+				diagnostic.Detail == pkg.Path()+".FutureBlocked" {
+				t.Fatalf("blocked superset entry was rejected: %#v", diagnostic)
+			}
+		}
+	})
+
+	t.Run("real absent from go rejects", func(t *testing.T) {
+		diagnostics := verifyOverrideParityPackage(pkg.Path(), pkg, ledger, nil, nil)
+		requireDiagnosticCode(t, diagnostics, "goscript/overrides:parity-unknown-symbol")
+	})
+
+	t.Run("blocked absent from go but exported by typescript rejects", func(t *testing.T) {
+		tsExports := map[string]typeScriptExport{"FutureBlocked": {value: true}}
+		diagnostics := verifyOverrideParityPackage(pkg.Path(), pkg, ledger, tsExports, nil)
+		requireDiagnosticCode(t, diagnostics, "goscript/overrides:parity-unexpected-export")
+		requireDiagnosticSeverity(t, diagnostics, "goscript/overrides:parity-unexpected-export", DiagnosticSeverityError)
+	})
+
+	t.Run("blocked present in go and exported by typescript rejects", func(t *testing.T) {
+		present := types.NewPackage("example.test/present", "present")
+		signature := types.NewSignatureType(nil, nil, nil, types.NewTuple(), types.NewTuple(), false)
+		present.Scope().Insert(types.NewFunc(token.NoPos, present, "BlockedNow", signature))
+		tsExports := map[string]typeScriptExport{"BlockedNow": {value: true}}
+		blockedLedger := overrideParityLedger{
+			SchemaVersion: 1,
+			Strict:        true,
+			Symbols: map[string]overrideParityEntry{
+				"BlockedNow": {Status: overrideParityStatusBlocked, Reason: "unsupported surface"},
+			},
+		}
+		diagnostics := verifyOverrideParityPackage(present.Path(), present, blockedLedger, tsExports, nil)
+		requireDiagnosticCode(t, diagnostics, "goscript/overrides:parity-unexpected-export")
+	})
 }

--- a/gs/database/sql/driver/parity.json
+++ b/gs/database/sql/driver/parity.json
@@ -89,6 +89,7 @@
     "RowsAffected": {
       "status": "real"
     },
+    "RowsColumnScanner": { "status": "blocked", "reason": "newer driver interface; not implemented by the wasm sql bridge" },
     "RowsColumnTypeDatabaseTypeName": {
       "status": "real"
     },
@@ -107,6 +108,7 @@
     "RowsNextResultSet": {
       "status": "real"
     },
+    "ScanContext": { "status": "blocked", "reason": "newer driver interface; not implemented by the wasm sql bridge" },
     "SessionResetter": {
       "status": "real"
     },

--- a/gs/encoding/json/parity.json
+++ b/gs/encoding/json/parity.json
@@ -2,18 +2,23 @@
   "schemaVersion": 1,
   "strict": true,
   "symbols": {
+    "CallMethodsWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "Compact": {
       "status": "real"
     },
     "Decoder": {
       "status": "real"
     },
+    "DefaultOptionsV1": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "Delim": {
       "status": "real"
     },
     "Encoder": {
       "status": "real"
     },
+    "FormatByteArrayAsArray": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "FormatBytesWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "FormatDurationAsNano": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "HTMLEscape": {
       "status": "real"
     },
@@ -38,6 +43,8 @@
     "MarshalIndent": {
       "status": "real"
     },
+    "MatchCaseSensitiveDelimiter": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "MergeWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "NewDecoder": {
       "status": "real"
     },
@@ -47,9 +54,15 @@
     "Number": {
       "status": "real"
     },
+    "OmitEmptyWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "Options": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "ParseBytesWithLooseRFC4648": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "ParseTimeWithLooseRFC3339": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "RawMessage": {
       "status": "real"
     },
+    "ReportErrorsWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
+    "StringifyWithLegacySemantics": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "SyntaxError": {
       "status": "real"
     },
@@ -59,6 +72,7 @@
     "Unmarshal": {
       "status": "real"
     },
+    "UnmarshalArrayFromAnyLength": { "status": "blocked", "reason": "encoding/json v2 legacy-semantics surface; the wasm override implements v1 semantics only" },
     "Unmarshaler": {
       "status": "real"
     },

--- a/gs/net/http/parity.json
+++ b/gs/net/http/parity.json
@@ -13,6 +13,7 @@
     "CrossOriginProtection": { "status": "real" },
     "DefaultClient": { "status": "real" },
     "DefaultMaxHeaderBytes": { "status": "real" },
+    "DefaultMaxHeaderValueCount": { "status": "blocked", "reason": "constant added in a newer stdlib; unused by the wasm http override" },
     "DefaultMaxIdleConnsPerHost": { "status": "real" },
     "DefaultServeMux": { "status": "real" },
     "DefaultTransport": { "status": "real" },

--- a/gs/reflect/functions.test.ts
+++ b/gs/reflect/functions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  Append,
+  Chan,
+  ChanOf,
+  BothDir,
+  Int,
+  MakeChan,
+  MakeMap,
+  MakeSlice,
+  Map,
+  MapOf,
+  Ptr,
+  PtrTo,
+  SliceOf,
+  Swapper,
+  TypeAssert,
+  TypeOf,
+  ValueOf,
+} from './index.js'
+
+// Locator test for the package-level function overrides that golden tests
+// only reach when the compiler runs inside this repository. Keeping these
+// assertions in-package makes parity behavior-test discovery independent of
+// the compiler working directory.
+describe('reflect package-level function overrides', () => {
+  it('appends a value to a reflected slice', () => {
+    const slice = MakeSlice(SliceOf(TypeOf(0)), 2, 4)
+    const grown = Append(slice, ValueOf(3))
+    expect(grown.Len()).toBe(3)
+  })
+
+  it('derives channel and pointer types', () => {
+    const elem = TypeOf(0)
+    expect(ChanOf(BothDir, elem).Kind()).toBe(Chan)
+    expect(PtrTo(elem)?.Kind()).toBe(Ptr)
+  })
+
+  it('makes a buffered channel value', () => {
+    const ch = MakeChan(ChanOf(BothDir, TypeOf(Int)), 2)
+    expect(ch.Kind()).toBe(Chan)
+  })
+
+  it('makes an empty map value', () => {
+    const map = MakeMap(MapOf(TypeOf(''), TypeOf(Int)))
+    expect(map.Kind()).toBe(Map)
+  })
+
+  it('swaps elements of a plain slice in place', () => {
+    const values = [1, 2, 3]
+    Swapper(values)(0, 2)
+    expect(values).toEqual([3, 2, 1])
+  })
+
+  it('type-asserts a reflected value without type arguments', () => {
+    const [value, ok] = TypeAssert(undefined, ValueOf('typed'))
+    expect(ok).toBe(true)
+    expect(value).toBe('typed')
+    expect(Int).toBeDefined()
+  })
+})

--- a/gs/strings/parity.json
+++ b/gs/strings/parity.json
@@ -29,6 +29,7 @@
     "Cut": {
       "status": "real"
     },
+    "CutLast": { "status": "blocked", "reason": "stdlib function added in a newer toolchain; not implemented by the override" },
     "CutPrefix": {
       "status": "real"
     },


### PR DESCRIPTION
Strict override parity ledgers currently reject any ledger symbol that the Go package does not export. That breaks a ledger written against a newer toolchain: a blocked row records a stdlib symbol that the newer toolchain exports and the wasm override intentionally does not provide, so the same parity.json compiles clean on one toolchain and fails with parity-unknown-symbol on an older one.

This change treats a blocked entry as a cross-toolchain superset. When the Go package lacks the symbol and TypeScript does not export it either, there is nothing to verify and the row passes. A TypeScript export standing in for a blocked symbol, and any non-blocked status without a matching Go export, still fails verification.

Blocked ledger rows are added for the encoding/json v2 legacy-semantics surface, the newer database/sql/driver RowsColumnScanner and ScanContext interfaces, net/http.DefaultMaxHeaderValueCount, and strings.CutLast, so manifest builds on current toolchains pass parity verification.

A new reflect functions test keeps behavior-test discovery for the package-level function overrides independent of the compiler working directory.
