### PR TITLE
fix(tests): remove unused async error fixtures

### DIFF
--- a/gs/errors/errors.async.test.ts
+++ b/gs/errors/errors.async.test.ts
@@ -50,7 +50,3 @@ describe('errors with async Error members', () => {
     expect(text as string).toBe('a\nb')
   })
 })
-
-// keep references to the exact member objects used in the Join test above
-const syncErr0 = (Join(syncError('a')) as any) && syncError('a')
-const joinedMembers = [syncError('a'), asyncError('b'), syncError('c')]

--- a/gs/fmt/fmt.async.test.ts
+++ b/gs/fmt/fmt.async.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
 import * as $ from '@goscript/builtin/index.js'
-import * as errors from '@goscript/errors/index.js'
 import * as fmt from './fmt.js'
 import { Sprint, Sprintf } from './fmt.js'
 


### PR DESCRIPTION
The tests-update workflow runs ESLint after regenerating its fixtures. Two stale constants in the async errors test and one stale import in the async fmt test cause that job to fail before it can publish the generated update.

Remove the unused declarations. The focused async errors and fmt tests retain the same behavioral coverage.