### PR TITLE
fix(compiler): resolve protobuf TS binding ctors from lowered import aliases

### DIFF
--- a/compiler/protobuf-ts-binding.go
+++ b/compiler/protobuf-ts-binding.go
@@ -774,12 +774,15 @@ func protobufTypeScriptBindingSplitDotted(ref string) (pkgName, typeName string,
 }
 
 // protobufTypeScriptBindingFieldCtor resolves the TypeScript class identifier
-// for a message-kind struct field from the lowered model instead of scanning
-// the declared type string, so non-pointer and aliased message fields resolve
-// the same way pointer fields do. It reports isMessage=false for fields that
-// reference no named struct. An unresolvable message-kind reference returns
-// ctor="" with isMessage=true so the caller can report a compile-time
-// diagnostic rather than silently omitting binding metadata.
+// for a message-kind struct field. The lowered runtime type expression remains
+// the authority for message kind and the referenced type name; the emitted
+// constructor comes from the declared field type so the qualifier is the
+// actual lowered import alias, which may differ from the dependency directory
+// basename and Go package clause. Same-package references resolve through the
+// bound message names. It reports isMessage=false for fields that reference
+// no named struct. An unresolvable message-kind reference returns ctor=""
+// with isMessage=true so the caller can report a compile-time diagnostic
+// rather than silently omitting binding metadata.
 func protobufTypeScriptBindingFieldCtor(field loweredStructField, pkgName string, file *loweredFile, binding protobufTypeScriptBinding) (ctor string, isMessage bool) {
 	refPkg, refType, ok := protobufTypeScriptBindingFieldMessageRef(field.runtimeType)
 	if !ok {
@@ -789,12 +792,58 @@ func protobufTypeScriptBindingFieldCtor(field loweredStructField, pkgName string
 		if _, bound := binding.messageNames[refType]; bound {
 			return refType, true
 		}
-	} else {
-		for _, imp := range file.imports {
-			if imp.alias == refPkg || strings.HasSuffix(imp.source, "/"+refPkg+"/index.js") {
-				return imp.alias + "." + refType, true
-			}
-		}
+		return "", true
 	}
-	return "", true
+	return protobufTypeScriptBindingImportedCtor(field.typ, refType, file), true
+}
+
+// protobufTypeScriptBindingImportedCtor resolves the emitted constructor for
+// an imported message reference by finding one lowered import whose alias
+// qualifies the referenced type name in the declared field type text. Only
+// named, non-type-only imports qualify; blank and type-only imports cannot
+// carry value constructors. Distinct qualifying imports leave the reference
+// ambiguous and return "" so the caller reports the unresolved diagnostic.
+func protobufTypeScriptBindingImportedCtor(typ, refType string, file *loweredFile) string {
+	matchAlias := ""
+	matchSource := ""
+	for _, imp := range file.imports {
+		if imp.alias == "" || imp.typeOnly {
+			continue
+		}
+		if !loweredTypQualifiesRef(typ, imp.alias, refType) {
+			continue
+		}
+		if matchAlias != "" && (matchAlias != imp.alias || matchSource != imp.source) {
+			return ""
+		}
+		matchAlias = imp.alias
+		matchSource = imp.source
+	}
+	if matchAlias == "" {
+		return ""
+	}
+	return matchAlias + "." + refType
+}
+
+// loweredTypQualifiesRef reports whether typ spells the referenced type name
+// qualified by exactly the given import alias at identifier boundaries.
+func loweredTypQualifiesRef(typ, alias, refType string) bool {
+	needle := alias + "." + refType
+	for offset := 0; ; offset++ {
+		idx := strings.Index(typ[offset:], needle)
+		if idx < 0 {
+			return false
+		}
+		idx += offset
+		start := idx + len(needle)
+		if (idx == 0 || !typIdentChar(typ[idx-1])) &&
+			(start == len(typ) || !typIdentChar(typ[start])) {
+			return true
+		}
+		offset = idx + 1
+	}
+}
+
+func typIdentChar(ch byte) bool {
+	return ch == '_' || ch == '$' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
 }

--- a/compiler/protobuf-ts-binding_test.go
+++ b/compiler/protobuf-ts-binding_test.go
@@ -814,3 +814,62 @@ export const Outer = {} as any
 		t.Fatalf("error should name the unresolved referenced type PlainHelper, got: %v", err)
 	}
 }
+
+func TestProtobufTypeScriptBindingResolvesAliasedCrossPackageCtors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "go.mod", "module example.test/aliaspb\n\ngo 1.25\n")
+	// The dependency directory basename (depimpl), Go package clause
+	// (remoteclause), and explicit consumer import alias (rdep) all differ.
+	writeTestFile(t, dir, "dep/depimpl/remote.pb.go", `package remoteclause
+
+type RemoteMsg struct {
+	Name string `+"`"+`protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`+"`"+`
+}
+
+func (x *RemoteMsg) CloneVT() *RemoteMsg {
+	return &RemoteMsg{Name: x.Name}
+}
+`)
+	writeTestFile(t, dir, "dep/depimpl/remote.pb.ts", `export interface RemoteMsg {
+  name?: string
+}
+export const RemoteMsg = {} as any
+`)
+	writeTestFile(t, dir, "foo.pb.go", `package aliaspb
+
+import rdep "example.test/aliaspb/dep/depimpl"
+
+type Outer struct {
+	Ptr  *rdep.RemoteMsg        `+"`"+`protobuf:"bytes,1,opt,name=ptr,proto3" json:"ptr,omitempty"`+"`"+`
+	Val  rdep.RemoteMsg         `+"`"+`protobuf:"bytes,2,opt,name=val,proto3" json:"val,omitempty"`+"`"+`
+	Rep  []*rdep.RemoteMsg      `+"`"+`protobuf:"bytes,3,rep,name=rep,proto3" json:"rep,omitempty"`+"`"+`
+	MapV map[string]*rdep.RemoteMsg `+"`"+`protobuf:"bytes,4,rep,name=map_v,json=mapV,proto3" json:"map_v,omitempty" protobuf_key:"bytes,0,opt,name=key" protobuf_val:"bytes,1,opt,name=value"`+"`"+`
+}
+`)
+	writeTestFile(t, dir, "foo.pb.ts", `import type { RemoteMsg } from './dep/depimpl/remote.pb.js'
+
+export interface Outer {
+  ptr?: RemoteMsg
+}
+export const Outer = {} as any
+`)
+
+	out := filepath.Join(dir, "out")
+	comp, err := NewCompiler(&Config{
+		Dir:                       dir,
+		OutputPath:                out,
+		ProtobufTypeScriptBinding: true,
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := comp.CompilePackages(context.Background(), "."); err != nil {
+		t.Fatalf("compile with protobuf TypeScript binding: %v", err)
+	}
+
+	binding := readTestFile(t, filepath.Join(out, "@goscript", "example.test", "aliaspb", "foo.pb.ts"))
+	wantFields := `(Outer as any).__protobufTypeScriptFields = {"mapV": rdep.RemoteMsg, "ptr": rdep.RemoteMsg, "rep": rdep.RemoteMsg, "val": rdep.RemoteMsg};`
+	if !strings.Contains(binding, wantFields) {
+		t.Fatalf("binding metadata should resolve pointer, value, repeated, and map-value fields through the actual import alias rdep\nwant: %s\ngot:\n%s", wantFields, binding)
+	}
+}


### PR DESCRIPTION
The protobuf TypeScript binding resolved imported message constructors by guessing the import alias from the referenced Go package name or the dependency directory basename. When a consumer imports a dependency with an explicit alias that differs from the dependency's Go package clause and its directory basename, both guesses miss and every message-kind field shape (pointer, value, repeated, map value) fails with the unresolved diagnostic.

This change keeps the lowered runtime type expression as the authority for message kind and the referenced type name, but derives the emitted constructor from the declared field type: it matches one named, non-type-only lowered import whose alias qualifies the referenced type name at identifier boundaries. Same-package references still resolve through the bound message names. Zero or multiple distinct qualifying imports keep the existing hard unresolved diagnostic instead of guessing.

The regression uses a dependency whose directory basename, Go package clause, and explicit consumer alias all differ, and covers pointer, value, repeated, and map-value message fields. The focused regression fails on master with goscript/protobuf-ts-binding:unresolved for all four shapes and passes after the fix.