### PR TITLE
fix(compiler): bind protobuf TS consts across digit-camel divergence

### DIFF
--- a/compiler/protobuf-ts-binding.go
+++ b/compiler/protobuf-ts-binding.go
@@ -194,6 +194,21 @@ func protobufTypeScriptBindingMessageNames(file *ast.File, tsPath string) map[st
 		return names
 	}
 	exportedTSMessages := protobufTypeScriptBindingExportedConsts(tsPath)
+
+	// Index exported consts case-insensitively so a Go safe identifier that
+	// differs from the protobuf-es const only in digit-camel capitalization,
+	// such as protoc-gen-go's V86Fs versus the exported const V86fs, still
+	// resolves to the actual exported spelling.
+	loweredTSMessages := make(map[string][]string, len(exportedTSMessages))
+	for export := range exportedTSMessages {
+		lowered := strings.ToLower(export)
+		loweredTSMessages[lowered] = append(loweredTSMessages[lowered], export)
+	}
+
+	// boundTSConsts records consts claimed by an earlier struct so two
+	// structs never bind to the same TypeScript const.
+	boundTSConsts := make(map[string]bool)
+
 	for _, decl := range file.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -209,10 +224,21 @@ func protobufTypeScriptBindingMessageNames(file *ast.File, tsPath string) map[st
 			}
 			name := typeSpec.Name.Name
 			safeName := protobufTypeScriptBindingSafeIdentifier(name)
-			if len(exportedTSMessages) != 0 && !exportedTSMessages[safeName] {
+			if len(exportedTSMessages) == 0 || exportedTSMessages[safeName] {
+				names[name] = safeName
+				boundTSConsts[safeName] = true
 				continue
 			}
-			names[name] = safeName
+
+			// Fall back to the case-insensitive index only when exactly one
+			// exported const matches; ambiguous or already-bound consts stay
+			// unbound and keep reporting the unresolved diagnostic.
+			matches := loweredTSMessages[strings.ToLower(safeName)]
+			if len(matches) != 1 || boundTSConsts[matches[0]] {
+				continue
+			}
+			names[name] = matches[0]
+			boundTSConsts[matches[0]] = true
 		}
 	}
 	return names
@@ -758,11 +784,11 @@ func protobufTypeScriptBindingFieldMessageRef(runtimeType string) (pkgName, type
 		return "", "", false
 	}
 	rest := runtimeType[idx+len(marker):]
-	end := strings.Index(rest, "\"")
-	if end < 0 {
+	before, _, ok0 := strings.Cut(rest, "\"")
+	if !ok0 {
 		return "", "", false
 	}
-	return protobufTypeScriptBindingSplitDotted(rest[:end])
+	return protobufTypeScriptBindingSplitDotted(before)
 }
 
 func protobufTypeScriptBindingSplitDotted(ref string) (pkgName, typeName string, ok bool) {

--- a/compiler/protobuf-ts-binding_test.go
+++ b/compiler/protobuf-ts-binding_test.go
@@ -873,3 +873,62 @@ export const Outer = {} as any
 		t.Fatalf("binding metadata should resolve pointer, value, repeated, and map-value fields through the actual import alias rdep\nwant: %s\ngot:\n%s", wantFields, binding)
 	}
 }
+
+// TestProtobufTypeScriptBindingBindsDigitCamelCaseDivergence verifies that
+// messages whose protoc-gen-go safe identifier differs from the protobuf-es
+// exported const only in digit-camel capitalization still bind, while exact
+// matches continue to bind to their own consts.
+func TestProtobufTypeScriptBindingBindsDigitCamelCaseDivergence(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "go.mod", "module example.test/protobufbindingdigitcamel\n\ngo 1.25\n")
+	writeTestFile(t, dir, "foo.pb.go", `package protobufbindingdigitcamel
+
+type V86Fs struct {
+	Name string
+}
+
+type ExactName struct {
+	Name string
+}
+`)
+	writeTestFile(t, dir, "foo.pb.ts", `export interface V86fs {
+  name?: string
+}
+export const V86fs = {} as any
+export interface ExactName {
+  name?: string
+}
+export const ExactName = {} as any
+`)
+	writeTestFile(t, dir, "use.go", `package protobufbindingdigitcamel
+
+func NewV86Fs() V86Fs {
+	return V86Fs{Name: "bound"}
+}
+
+func NewExactName() ExactName {
+	return ExactName{Name: "exact"}
+}
+`)
+
+	out := filepath.Join(dir, "out")
+	comp, err := NewCompiler(&Config{
+		Dir:                       dir,
+		OutputPath:                out,
+		ProtobufTypeScriptBinding: true,
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := comp.CompilePackages(context.Background(), "."); err != nil {
+		t.Fatalf("compile with protobuf TypeScript binding: %v", err)
+	}
+
+	binding := readTestFile(t, filepath.Join(out, "@goscript", "example.test", "protobufbindingdigitcamel", "foo.pb.ts"))
+	if !strings.Contains(binding, `__protobufTypeScriptMessage = __protobuf_ts.V86fs;`) {
+		t.Fatalf("digit-camel diverged message should bind to the protobuf-es const V86fs, got:\n%s", binding)
+	}
+	if !strings.Contains(binding, `__protobufTypeScriptMessage = __protobuf_ts.ExactName;`) {
+		t.Fatalf("exactly matching message should still bind to its own const, got:\n%s", binding)
+	}
+}


### PR DESCRIPTION
protoc-gen-go capitalizes the letter following a digit when it derives a Go struct name from a proto message, so a message spelled V86fs becomes the Go struct V86Fs. protobuf-es generated .pb.ts files keep the proto spelling and export const V86fs. The protobuf TypeScript binding kept a Go struct only when its safe identifier appeared exactly as an exported const in the .pb.ts file, so every message in packages such as db/unixfs/v86fs went unbound and their same-package oneof wrapper fields failed with goscript/protobuf-ts-binding:unresolved.

The binding now builds a case-insensitive index of the exported .pb.ts consts and falls back to it when the exact safe-identifier lookup misses. Exact matches are checked first and behave as before. The fallback binds only when exactly one exported const matches case-insensitively and no earlier struct has already claimed that const, and a bound struct references the actual exported spelling rather than assuming the Go-side one. Ambiguous case-collisions stay unbound and keep reporting the existing unresolved diagnostic, so matching remains fail-closed.

Adds TestProtobufTypeScriptBindingBindsDigitCamelCaseDivergence, which binds a Go V86Fs struct against a generated const V86fs while asserting that an exactly-matching struct still binds exactly.