### PR TITLE
fix(compiler): bind protobuf TS fields across same-package files

### DIFF
--- a/compiler/protobuf-ts-binding.go
+++ b/compiler/protobuf-ts-binding.go
@@ -15,6 +15,52 @@ type protobufTypeScriptBinding struct {
 	importSource string
 	messageNames map[string]string
 	hasOneof     bool
+
+	// packageMessages maps every message bound by any binding file in the
+	// same package to the sibling binding that publishes it. Field
+	// resolution consults it for same-package cross-file references.
+	packageMessages map[string]protobufTypeScriptBoundMessage
+}
+
+// protobufTypeScriptBoundMessage records the sibling binding file that
+// publishes a bound message class.
+type protobufTypeScriptBoundMessage struct {
+	importSource string
+	outputName   string
+}
+
+// protobufTypeScriptBindingSiblingImports mints side-effect imports of
+// sibling binding files so a same-package cross-file field constructor can
+// qualify the referenced message class.
+type protobufTypeScriptBindingSiblingImports struct {
+	file    *loweredFile
+	aliases map[string]string
+}
+
+// aliasFor returns the import alias for a sibling binding file, adding the
+// side-effect import on first use.
+func (s *protobufTypeScriptBindingSiblingImports) aliasFor(importSource, outputName string) string {
+	if s.aliases == nil {
+		s.aliases = make(map[string]string)
+	}
+	if alias, ok := s.aliases[importSource]; ok {
+		return alias
+	}
+	base := "__protobuf_ts_" + safeIdentifier(strings.TrimSuffix(outputName, ".ts"))
+	reserved := make(map[string]bool, len(s.file.imports))
+	for _, imp := range s.file.imports {
+		if imp.alias != "" {
+			reserved[imp.alias] = true
+		}
+	}
+	alias := uniqueImportAlias(base, importSource, nil, reserved)
+	s.aliases[importSource] = alias
+	s.file.imports = append(s.file.imports, loweredImport{
+		alias:      alias,
+		source:     importSource,
+		sideEffect: true,
+	})
+	return alias
 }
 
 type protobufTypeScriptBindingOneofCase struct {
@@ -81,6 +127,23 @@ func protobufTypeScriptBindings(semPkg *semanticPackage, options LoweringOptions
 			messageNames: messageNames,
 			hasOneof:     protobufTypeScriptBindingHasOneof(syntax),
 		}
+	}
+
+	// Index the bound messages across all binding files so a field in one
+	// file can resolve a reference to a message declared in another file of
+	// the same package.
+	packageMessages := make(map[string]protobufTypeScriptBoundMessage, len(bindings))
+	for _, binding := range bindings {
+		for name := range binding.messageNames {
+			packageMessages[name] = protobufTypeScriptBoundMessage{
+				importSource: binding.importSource,
+				outputName:   binding.outputName,
+			}
+		}
+	}
+	for sourcePath, binding := range bindings {
+		binding.packageMessages = packageMessages
+		bindings[sourcePath] = binding
 	}
 	return bindings, diagnostics
 }
@@ -352,7 +415,8 @@ func rewriteProtobufTypeScriptBindingFile(file *loweredFile, binding protobufTyp
 		source:     binding.importSource,
 		sideEffect: true,
 	})
-	oneofCases := protobufTypeScriptBindingOneofCases(file, pkgName, binding, &diagnostics)
+	siblings := &protobufTypeScriptBindingSiblingImports{file: file}
+	oneofCases := protobufTypeScriptBindingOneofCases(file, pkgName, binding, siblings, &diagnostics)
 	oneofBranches := make(map[string]bool)
 	for _, cases := range oneofCases {
 		for _, oneofCase := range cases {
@@ -372,7 +436,7 @@ func rewriteProtobufTypeScriptBindingFile(file *loweredFile, binding protobufTyp
 		if !ok {
 			continue
 		}
-		setup, setupDiagnostics := protobufTypeScriptBindingStructSetupDecl(decl.structType, importAlias, messageName, pkgName, file, binding, oneofCases[decl.structType.name])
+		setup, setupDiagnostics := protobufTypeScriptBindingStructSetupDecl(decl.structType, importAlias, messageName, pkgName, file, binding, siblings, oneofCases[decl.structType.name])
 		diagnostics = append(diagnostics, setupDiagnostics...)
 		if setup.code != "" {
 			setupDecls = append(setupDecls, setup)
@@ -382,7 +446,7 @@ func rewriteProtobufTypeScriptBindingFile(file *loweredFile, binding protobufTyp
 	return diagnostics
 }
 
-func protobufTypeScriptBindingOneofCases(file *loweredFile, pkgName string, binding protobufTypeScriptBinding, diagnostics *[]Diagnostic) map[string][]protobufTypeScriptBindingOneofCase {
+func protobufTypeScriptBindingOneofCases(file *loweredFile, pkgName string, binding protobufTypeScriptBinding, siblings *protobufTypeScriptBindingSiblingImports, diagnostics *[]Diagnostic) map[string][]protobufTypeScriptBindingOneofCase {
 	parentByName := make(map[string]*loweredStruct)
 	for _, decl := range file.decls {
 		if decl.structType != nil {
@@ -411,7 +475,7 @@ func protobufTypeScriptBindingOneofCases(file *loweredFile, pkgName string, bind
 			if !strings.Contains(field.tag, "oneof") {
 				continue
 			}
-			valueCtor, isMessage := protobufTypeScriptBindingFieldCtor(field, pkgName, file, binding)
+			valueCtor, isMessage := protobufTypeScriptBindingFieldCtor(field, pkgName, file, binding, siblings)
 			if isMessage && valueCtor == "" {
 				*diagnostics = append(*diagnostics, Diagnostic{
 					Severity: DiagnosticSeverityError,
@@ -642,7 +706,7 @@ func protobufBindingParam(method *loweredFunction, idx int, fallback string) str
 	return method.params[idx].name
 }
 
-func protobufTypeScriptBindingStructSetupDecl(structType *loweredStruct, importAlias, messageName, pkgName string, file *loweredFile, binding protobufTypeScriptBinding, oneofCases []protobufTypeScriptBindingOneofCase) (loweredDecl, []Diagnostic) {
+func protobufTypeScriptBindingStructSetupDecl(structType *loweredStruct, importAlias, messageName, pkgName string, file *loweredFile, binding protobufTypeScriptBinding, siblings *protobufTypeScriptBindingSiblingImports, oneofCases []protobufTypeScriptBindingOneofCase) (loweredDecl, []Diagnostic) {
 	if structType == nil {
 		return loweredDecl{}, nil
 	}
@@ -655,7 +719,7 @@ func protobufTypeScriptBindingStructSetupDecl(structType *loweredStruct, importA
 		if strings.Contains(field.tag, "protobuf_oneof") {
 			continue
 		}
-		ctor, isMessage := protobufTypeScriptBindingFieldCtor(field, pkgName, file, binding)
+		ctor, isMessage := protobufTypeScriptBindingFieldCtor(field, pkgName, file, binding, siblings)
 		if !isMessage {
 			continue
 		}
@@ -809,11 +873,14 @@ func protobufTypeScriptBindingSplitDotted(ref string) (pkgName, typeName string,
 // constructor comes from the declared field type so the qualifier is the
 // actual lowered import alias, which may differ from the dependency directory
 // basename and Go package clause. Same-package references resolve through the
-// bound message names. It reports isMessage=false for fields that reference
-// no named struct. An unresolvable message-kind reference returns ctor=""
-// with isMessage=true so the caller can report a compile-time diagnostic
-// rather than silently omitting binding metadata.
-func protobufTypeScriptBindingFieldCtor(field loweredStructField, pkgName string, file *loweredFile, binding protobufTypeScriptBinding) (ctor string, isMessage bool) {
+// bound message names of the current file and then through the package-wide
+// registry for messages declared in another file of the same package,
+// qualifying the sibling binding's class with a dedicated import. It reports
+// isMessage=false for fields that reference no named struct. An unresolvable
+// message-kind reference returns ctor="" with isMessage=true so the caller
+// can report a compile-time diagnostic rather than silently omitting binding
+// metadata.
+func protobufTypeScriptBindingFieldCtor(field loweredStructField, pkgName string, file *loweredFile, binding protobufTypeScriptBinding, siblings *protobufTypeScriptBindingSiblingImports) (ctor string, isMessage bool) {
 	refPkg, refType, ok := protobufTypeScriptBindingFieldMessageRef(field.runtimeType)
 	if !ok {
 		return "", false
@@ -822,7 +889,14 @@ func protobufTypeScriptBindingFieldCtor(field loweredStructField, pkgName string
 		if _, bound := binding.messageNames[refType]; bound {
 			return refType, true
 		}
-		return "", true
+
+		// Same proto package, different file: bind through the sibling
+		// binding file's published message class.
+		sibling, crossFile := binding.packageMessages[refType]
+		if !crossFile {
+			return "", true
+		}
+		return siblings.aliasFor(sibling.importSource, sibling.outputName) + "." + protobufTypeScriptBindingSafeIdentifier(refType), true
 	}
 	return protobufTypeScriptBindingImportedCtor(field.typ, refType, file), true
 }

--- a/compiler/protobuf-ts-binding_test.go
+++ b/compiler/protobuf-ts-binding_test.go
@@ -984,3 +984,81 @@ func NewExactName() ExactName {
 		t.Fatalf("exactly matching message should still bind to its own const, got:\n%s", binding)
 	}
 }
+
+// TestProtobufTypeScriptBindingResolvesSamePackageCrossFileRefs verifies
+// that a message-kind field whose reference resolves to a message declared
+// in another binding file of the same proto package binds through the
+// sibling binding file's published message class.
+func TestProtobufTypeScriptBindingResolvesSamePackageCrossFileRefs(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "go.mod", "module example.test/crossfilepb\n\ngo 1.25\n")
+	writeTestFile(t, dir, "root.pb.go", `package crossfilepb
+
+type WorldSnapshot struct {
+	Tick int64 `+"`"+`protobuf:"varint,1,opt,name=tick,proto3" json:"tick,omitempty"`+"`"+`
+}
+
+type WorldEvent struct {
+	Name string `+"`"+`protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`+"`"+`
+}
+`)
+	writeTestFile(t, dir, "root.pb.ts", `export interface WorldSnapshot {
+  tick?: string
+}
+export const WorldSnapshot = {} as any
+export interface WorldEvent {
+  name?: string
+}
+export const WorldEvent = {} as any
+`)
+	writeTestFile(t, dir, "world_storage.pb.go", `package crossfilepb
+
+type MercuryWorldTickCommit struct {
+	SnapshotCheckpoint *WorldSnapshot `+"`"+`protobuf:"bytes,1,opt,name=snapshot_checkpoint,json=snapshotCheckpoint,proto3" json:"snapshot_checkpoint,omitempty"`+"`"+`
+}
+
+type MercuryWorldEventBatch struct {
+	Events []*WorldEvent `+"`"+`protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`+"`"+`
+}
+`)
+	writeTestFile(t, dir, "world_storage.pb.ts", `import { WorldEvent, WorldSnapshot } from './root.pb.js'
+
+export interface MercuryWorldTickCommit {
+  snapshotCheckpoint?: WorldSnapshot
+}
+export const MercuryWorldTickCommit = {} as any
+export interface MercuryWorldEventBatch {
+  events?: WorldEvent[]
+}
+export const MercuryWorldEventBatch = {} as any
+`)
+
+	out := filepath.Join(dir, "out")
+	comp, err := NewCompiler(&Config{
+		Dir:                       dir,
+		OutputPath:                out,
+		ProtobufTypeScriptBinding: true,
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := comp.CompilePackages(context.Background(), "."); err != nil {
+		t.Fatalf("compile with protobuf TypeScript binding: %v", err)
+	}
+
+	storage := readTestFile(t, filepath.Join(out, "@goscript", "example.test", "crossfilepb", "world_storage.pb.ts"))
+	wantSnippets := []string{
+		`(MercuryWorldTickCommit as any).__protobufTypeScriptFields = {"snapshotCheckpoint": __protobuf_ts_root_pb.WorldSnapshot};`,
+		`(MercuryWorldEventBatch as any).__protobufTypeScriptFields = {"events": __protobuf_ts_root_pb.WorldEvent};`,
+	}
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(storage, snippet) {
+			t.Fatalf("storage binding should resolve same-package cross-file message fields through the sibling binding\nwant: %s\ngot:\n%s", snippet, storage)
+		}
+	}
+	root := readTestFile(t, filepath.Join(out, "@goscript", "example.test", "crossfilepb", "root.pb.ts"))
+	if !strings.Contains(root, `__protobufTypeScriptMessage = __protobuf_ts.WorldSnapshot;`) ||
+		!strings.Contains(root, `__protobufTypeScriptMessage = __protobuf_ts.WorldEvent;`) {
+		t.Fatalf("sibling binding should keep binding its own messages, got:\n%s", root)
+	}
+}


### PR DESCRIPTION
A message-kind field whose reference resolves to a type declared in another .pb.go file of the same proto package fell through to the goscript/protobuf-ts-binding:unresolved diagnostic, because field resolution only consulted the bound message names of the current file. The Mercury hosted compile gate hit this on mercury_game.WorldSnapshot and mercury_game.WorldEvent referenced from sdk/game/world_storage.proto: same package, different file, connected by a proto import.

The binding pass now indexes the bound messages of every binding file in a package-wide registry. When a same-package field reference misses the current file's names, resolution falls back to that registry and qualifies the sibling binding's message class with a dedicated side-effect import of the sibling .pb.js, minted once per file through the existing unique import alias mechanism. The fallback is fail-closed: a reference that matches no bound message in the package still reports unresolved.

Exact same-file bindings, cross-package import-alias references, and digit-camel capitalization divergence keep their existing resolution paths. Adds TestProtobufTypeScriptBindingResolvesSamePackageCrossFileRefs, which compiles a two-file same-package proto pair with pointer and slice-of-pointer fields referencing messages from the sibling file.