### PR TITLE
perf(runtime): index string map keys and constant byte lookups

### DIFF
--- a/compiler/lowering.go
+++ b/compiler/lowering.go
@@ -11023,6 +11023,21 @@ func (o *LoweringOwner) lowerIndexExpr(ctx lowerFileContext, expr *ast.IndexExpr
 	targetType := ctx.semPkg.source.TypesInfo.TypeOf(expr.X)
 	switch {
 	case isStringType(targetType):
+		// A constant string lookup needs one byte, not a fresh UTF-8 buffer.
+		// Encode each Go byte as a JS code unit, including invalid UTF-8 bytes.
+		value := ctx.semPkg.source.TypesInfo.Types[unwrapParenExpr(expr.X)].Value
+		if value != nil && value.Kind() == constant.String {
+			encoded := hex.EncodeToString([]byte(constant.StringVal(value)))
+			var literal strings.Builder
+			literal.WriteByte('"')
+			for i := 0; i < len(encoded); i += 2 {
+				literal.WriteString(`\x`)
+				literal.WriteString(encoded[i : i+2])
+			}
+			literal.WriteByte('"')
+			return o.runtimeOwner.QualifiedHelper(RuntimeHelperIndexByteString) + "(" + literal.String() + ", " + o.lowerNumberIndexValue(ctx, expr.Index, index) + ")", diagnostics
+		}
+
 		return o.runtimeOwner.QualifiedHelper(RuntimeHelperIndexStringOrBytes) + "(" + target + ", " + o.lowerNumberIndexValue(ctx, expr.Index, index) + ")", diagnostics
 	case isMapType(targetType):
 		return o.lowerMapGetValue(ctx, expr, target, index), diagnostics
@@ -11506,7 +11521,7 @@ func (o *LoweringOwner) lowerMapCompositeLit(
 		value = o.lowerValueForTarget(ctx, keyed.Value, mapType.Elem(), value)
 		entries = append(entries, "["+key+", "+value+"]")
 	}
-	return "new " + tsNativeMapType(o.tsTypeFor(ctx, mapType.Key()), o.tsTypeFor(ctx, mapType.Elem())) + "([" + strings.Join(entries, ", ") + "])", diagnostics
+	return o.runtimeOwner.QualifiedHelper(RuntimeHelperMakeMap) + "<" + o.tsTypeFor(ctx, mapType.Key()) + ", " + o.tsTypeFor(ctx, mapType.Elem()) + ">([" + strings.Join(entries, ", ") + "])", diagnostics
 }
 
 func tsNativeMapType(keyType, elemType string) string {

--- a/compiler/runtime-contract.go
+++ b/compiler/runtime-contract.go
@@ -115,6 +115,7 @@ const (
 	RuntimeHelperStringHeaderRef              RuntimeHelper = "slice.stringHeaderRef"
 	RuntimeHelperSliceHeaderRef               RuntimeHelper = "slice.sliceHeaderRef"
 	RuntimeHelperGenericBytesOrStringToString RuntimeHelper = "slice.genericBytesOrStringToString"
+	RuntimeHelperIndexByteString              RuntimeHelper = "slice.indexByteString"
 	RuntimeHelperIndexStringOrBytes           RuntimeHelper = "slice.indexStringOrBytes"
 	RuntimeHelperArrayIndex                   RuntimeHelper = "slice.arrayIndex"
 	RuntimeHelperSliceStringOrBytes           RuntimeHelper = "slice.sliceStringOrBytes"
@@ -364,6 +365,7 @@ func runtimeHelperContracts() []RuntimeHelperContract {
 		runtimeHelper(RuntimeHelperStringHeaderRef, "stringHeaderRef", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperSliceHeaderRef, "sliceHeaderRef", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperGenericBytesOrStringToString, "genericBytesOrStringToString", RuntimeHelperCategorySlice),
+		runtimeHelper(RuntimeHelperIndexByteString, "indexByteString", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperIndexStringOrBytes, "indexStringOrBytes", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperArrayIndex, "arrayIndex", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperSliceStringOrBytes, "sliceStringOrBytes", RuntimeHelperCategorySlice),

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -475,7 +475,7 @@ After reviewing the code and tests, some important implementation considerations
     -   **Sparse Array Literals:** For Go array literals with specific indices (e.g., `[5]int{1: 10, 3: 30}`), unspecified indices are filled with the zero value of the element type in the generated TypeScript. For example, `[5]int{1: 10, 3: 30}` becomes `[0, 10, 0, 30, 0]`.
 
 *Note: The distinction between slices and arrays in Go is important. While both often map to TypeScript arrays, runtime helpers (`makeSlice`, `slice`, `len`, `cap`, `append`) and the `__capacity` property are essential for emulating Go's slice semantics accurately.*
-- **Maps:** Go maps (`map[K]V`) are translated to TypeScript's standard `Map<K, V>` objects. Various Go map operations are mapped as follows:
+- **Maps:** Go maps (`map[K]V`) use a `Map<K, V>` subclass created by `$.makeMap`. It indexes string keys by their Go byte value, so misses and insertions do not scan existing entries. Binary and UTF-8 string representations share a key while iteration retains the original representation. Struct keys still use Go value comparison. Various Go map operations are mapped as follows:
     -   **Creation (`make`):** `make(map[K]V)` is translated using a runtime helper:
         ```go
         m := make(map[string]int)
@@ -485,13 +485,13 @@ After reviewing the code and tests, some important implementation considerations
         import * as $ from "@goscript/builtin"
         let m = $.makeMap<string, number>() // Using generics for type information
         ```
-    -   **Literals:** Map literals are translated to `new Map(...)`:
+    -   **Literals:** Map literals use the same `$.makeMap` owner with initial entries:
         ```go
         m := map[string]int{"one": 1, "two": 2}
         ```
         becomes:
         ```typescript
-        let m = new Map([["one", 1], ["two", 2]])
+        let m = $.makeMap([["one", 1], ["two", 2]])
         ```
     -   **Assignment (`m[k] = v`):** Uses a runtime helper `mapSet`:
         ```go
@@ -501,15 +501,15 @@ After reviewing the code and tests, some important implementation considerations
         ```typescript
         $.mapSet(m, "three", 3)
         ```
-    -   **Access (`m[k]`):** Uses the standard `Map.get()` method combined with the nullish coalescing operator (`??`) to provide the zero value if the key is not found.
+    -   **Access (`m[k]`):** Uses `$.mapGet` to preserve both Go key equality and presence, including a stored undefined value.
         ```go
         val := m["one"] // Assuming m["one"] exists
         zero := m["nonexistent"] // Assuming m["nonexistent"] doesn't exist
         ```
         becomes (simplified conceptual translation):
         ```typescript
-        let val = m.get("one") ?? 0 // Provide zero value (0 for int) if undefined
-        let zero = m.get("nonexistent") ?? 0 // Provide zero value (0 for int) if undefined
+        let val = $.mapGet(m, "one", 0)[0]
+        let zero = $.mapGet(m, "nonexistent", 0)[0]
         ```
     -   **Comma-Ok Idiom (`v, ok := m[k]`):** Translated using `Map.has()` and `Map.get()` with zero-value handling during assignment:
         ```go

--- a/gs/builtin/map.test.ts
+++ b/gs/builtin/map.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deleteMapEntry, makeMap, mapGet, mapHas, mapSet } from './map.js'
+import { bytesToString, GoBinaryString } from './slice.js'
+
+describe('Go map string keys', () => {
+  it('does not scan existing entries for string misses or insertion', () => {
+    const map = makeMap<string, number>([['initial', 0]])
+    for (let i = 0; i < 4096; i++) mapSet(map, `key-${i}`, i)
+    const entries = vi.spyOn(map, 'entries')
+    expect(mapGet(map, 'absent', -1)).toEqual([-1, false])
+    expect(mapHas(map, 'absent')).toBe(false)
+    deleteMapEntry(map, 'absent')
+    mapSet(map, 'new', 4096)
+    expect(entries).not.toHaveBeenCalled()
+    expect(mapGet(map, 'new', -1)).toEqual([4096, true])
+  })
+
+  it('indexes binary, UTF-8, empty, and stored undefined values consistently', () => {
+    const map = makeMap<string | GoBinaryString, number | undefined>()
+    for (const bytes of [
+      new Uint8Array(),
+      new Uint8Array([0, 255, 65]),
+      new TextEncoder().encode('你好'),
+    ]) {
+      const wrapped = new GoBinaryString(bytes)
+      const key = bytesToString(bytes)
+      mapSet(map, wrapped, 1)
+      mapSet(map, key, undefined)
+      expect(map.size).toBe(1)
+      expect(mapGet(map, key, 99)).toEqual([undefined, true])
+      expect(mapGet(map, new GoBinaryString(bytes), 99)).toEqual([
+        undefined,
+        true,
+      ])
+      expect([...map.keys()]).toEqual([wrapped])
+      deleteMapEntry(map, key)
+      expect(map.size).toBe(0)
+      mapSet(map, key, 2)
+      map.clear()
+      expect(mapHas(map, wrapped)).toBe(false)
+    }
+  })
+})

--- a/gs/builtin/map.ts
+++ b/gs/builtin/map.ts
@@ -1,21 +1,56 @@
 import { comparableEqual } from './builtin.js'
-import { GoBinaryString, stringEqual } from './slice.js'
+import { GoBinaryString, stringEqual, stringMapKey } from './slice.js'
 
-/**
- * makeMap Creates a new map (TypeScript Map).
- * @returns A new TypeScript Map.
- */
-export const makeMap = <K, V>(): Map<K, V> => {
-  return new Map<K, V>()
+// GoMap indexes Go string representations by their canonical byte value.
+// Iteration retains the original key; object and struct equality stays in the
+// shared comparison path below. Non-string maps allocate no secondary index.
+class GoMap<K, V> extends Map<K, V> {
+  private stringKeys?: Map<string, K>
+
+  override set(key: K, value: V): this {
+    if (isGoStringKey(key)) {
+      const canonical = stringMapKey(key)
+      this.stringKeys ??= new Map<string, K>()
+      key = this.stringKeys.get(canonical) ?? key
+      this.stringKeys.set(canonical, key)
+    }
+    return super.set(key, value)
+  }
+
+  override get(key: K): V | undefined {
+    return super.get(this.storedKey(key))
+  }
+
+  override has(key: K): boolean {
+    return super.has(this.storedKey(key))
+  }
+
+  override delete(key: K): boolean {
+    const stored = this.storedKey(key)
+    if (isGoStringKey(key)) this.stringKeys?.delete(stringMapKey(key))
+    return super.delete(stored)
+  }
+
+  override clear(): void {
+    this.stringKeys?.clear()
+    super.clear()
+  }
+
+  private storedKey(key: K): K {
+    return isGoStringKey(key) ?
+        (this.stringKeys?.get(stringMapKey(key)) ?? key)
+      : key
+  }
 }
 
-/**
- * mapGet Gets a value from a map, returning a tuple [value, exists].
- * @param map The map to get from.
- * @param key The key to get.
- * @param defaultValue The default value to return if the key doesn't exist.
- * @returns A tuple [value, exists] where value is the map value or defaultValue, and exists is whether the key was found.
- */
+// makeMap creates a Go map with indexed string-value equality.
+export function makeMap<K, V>(entries?: Iterable<readonly [K, V]>): Map<K, V> {
+  const map = new GoMap<K, V>()
+  if (entries) for (const [key, value] of entries) mapSet(map, key, value)
+  return map
+}
+
+// mapGet returns the value and presence without confusing stored undefined with a miss.
 export function mapGet<K, V, D>(
   map: Map<K, V> | null,
   key: K,
@@ -29,12 +64,7 @@ export function mapGet<K, V, D>(
   }
 }
 
-/**
- * mapSet Sets a value in a map.
- * @param map The map to set in.
- * @param key The key to set.
- * @param value The value to set.
- */
+// mapSet preserves the existing equal key when replacing its value.
 export const mapSet = <K, V>(map: Map<K, V> | null, key: K, value: V): void => {
   if (!map) {
     throw new Error('assign to nil map')
@@ -43,11 +73,7 @@ export const mapSet = <K, V>(map: Map<K, V> | null, key: K, value: V): void => {
   map.set(entry.found ? entry.key : key, value)
 }
 
-/**
- * deleteMapEntry Deletes a key from a map.
- * @param map The map to delete from.
- * @param key The key to delete.
- */
+// deleteMapEntry removes a key using Go value equality.
 export const deleteMapEntry = <K, V>(map: Map<K, V> | null, key: K): void => {
   const entry = findMapEntry(map, key)
   if (entry.found) {
@@ -55,12 +81,7 @@ export const deleteMapEntry = <K, V>(map: Map<K, V> | null, key: K): void => {
   }
 }
 
-/**
- * mapHas Checks if a key exists in a map.
- * @param map The map to check in.
- * @param key The key to check.
- * @returns True if the key exists, false otherwise.
- */
+// mapHas reports membership using Go value equality.
 export const mapHas = <K, V>(map: Map<K, V> | null, key: K): boolean => {
   return findMapEntry(map, key).found
 }
@@ -76,6 +97,7 @@ function findMapEntry<K, V>(
     return { found: true, key, value: map.get(key)! }
   }
   if (isGoStringKey(key)) {
+    if (map instanceof GoMap) return { found: false }
     for (const [candidate, value] of map.entries()) {
       if (
         isGoStringKey(candidate) &&

--- a/gs/builtin/slice.test.ts
+++ b/gs/builtin/slice.test.ts
@@ -12,6 +12,7 @@ import {
   copy,
   goSlice,
   indexString,
+  indexByteString,
   len,
   makeSlice,
   runeToString,
@@ -24,6 +25,14 @@ import {
 import { markAsStructValue } from './type.js'
 
 describe('compiler byte constants', () => {
+  it('indexes encoded constants by byte with Go bounds checks', () => {
+    expect(indexByteString('\x00\xff\x07\xe4\xbd\xa0', 1)).toBe(255)
+    expect(indexByteString('\x00\xff\x07\xe4\xbd\xa0', 2)).toBe(7)
+    expect(indexByteString('\x00\xff\x07\xe4\xbd\xa0', 4)).toBe(189)
+    expect(() => indexByteString('a', -1)).toThrow()
+    expect(() => indexByteString('a', 1)).toThrow()
+  })
+
   it('decodes compact hexadecimal byte arrays', () => {
     expect(bytesFromHex('00ff8041')).toEqual(new Uint8Array([0, 255, 128, 65]))
   })

--- a/gs/builtin/slice.ts
+++ b/gs/builtin/slice.ts
@@ -61,6 +61,15 @@ function goStringBytes(str: GoStringValue): Uint8Array {
   return sharedTextEncoder.encode(str)
 }
 
+// stringMapKey gives every Go string representation the same native Map key.
+// Ordinary JavaScript strings are already canonical and need no byte conversion.
+export function stringMapKey(value: string | GoBinaryString): string {
+  if (typeof value === 'string' && !value.startsWith(goBinaryStringPrefix)) {
+    return value
+  }
+  return goStringFromBytes(goStringBytes(value))
+}
+
 function goStringComparableBytes(value: GoStringBytes): Uint8Array {
   if (isGoStringValue(value)) {
     return goStringBytes(value)
@@ -2409,6 +2418,13 @@ export function genericBytesOrStringToString(
     return value as string
   }
   return bytesToString(value)
+}
+
+// indexByteString indexes compiler-encoded byte constants without allocating a
+// UTF-8 buffer. Each JavaScript code unit represents exactly one original byte.
+export function indexByteString(value: string, index: number): number {
+  if (index < 0 || index >= value.length) outOfRangeIndex(index, value.length)
+  return value.charCodeAt(index)
 }
 
 /**

--- a/tests/tests/map_support/map_support.gs.ts
+++ b/tests/tests/map_support/map_support.gs.ts
@@ -48,7 +48,7 @@ export async function main(): globalThis.Promise<void> {
 	await $.println("After delete, does Charlie exist? Expected: false, Actual:", exists)
 
 	// Create map with literal syntax
-	let colors: globalThis.Map<string, string> | null = new globalThis.Map<string, string>([["red", "#ff0000"], ["green", "#00ff00"], ["blue", "#0000ff"]])
+	let colors: globalThis.Map<string, string> | null = $.makeMap<string, string>([["red", "#ff0000"], ["green", "#00ff00"], ["blue", "#0000ff"]])
 	await $.println("Map literal size: Expected: 3, Actual:", $.len(colors))
 	await $.println("Color code for red: Expected: #ff0000, Actual:", $.mapGet<string, string, string>(colors, "red", "")[0])
 
@@ -56,7 +56,7 @@ export async function main(): globalThis.Promise<void> {
 	await $.println("Iterating over scores map:")
 
 	// Create a new map with string keys and string values for testing iteration
-	let stringMap: globalThis.Map<string, string> | null = new globalThis.Map<string, string>([["Alice", "A+"], ["Bob", "B+"], ["Charlie", "A"]])
+	let stringMap: globalThis.Map<string, string> | null = $.makeMap<string, string>([["Alice", "A+"], ["Bob", "B+"], ["Charlie", "A"]])
 
 	// Note: Map iteration is not ordered in Go, so we will collect the results and sort them for consistent test output.
 	let scoreResults: $.Slice<string> = null! as $.Slice<string>

--- a/tests/tests/string_index_access/expected.log
+++ b/tests/tests/string_index_access/expected.log
@@ -5,3 +5,11 @@ Byte from myStr2[0]: 228
 Byte from myStr2[1]: 189
 Byte from myStr2[2]: 160
 Byte from myStr2[3]: 229
+constant byte 0
+constant byte 255
+constant byte 7
+constant byte 228
+constant byte 189
+constant byte 160
+out of bounds true
+out of bounds true

--- a/tests/tests/string_index_access/string_index_access.go
+++ b/tests/tests/string_index_access/string_index_access.go
@@ -7,14 +7,23 @@ func main() {
 	println("Byte from myStr1[6]:", myStr1[6]) // Expected: g (byte value 103)
 
 	myStr2 := "你好世界" // "Hello World" in Chinese
-	// Accessing bytes of multi-byte characters
-	// '你' is E4 BD A0 in UTF-8
-	// '好' is E5 A5 BD in UTF-8
-	// '世' is E4 B8 96 in UTF-8
-	// '界' is E7 95 C2 8C in UTF-8 (界 seems to be E7 95 8C, let's assume 3 bytes for simplicity in this example)
-	// For "你好世界", bytes are: E4 BD A0 E5 A5 BD E4 B8 96 E7 95 8C
+	// String indexing returns UTF-8 bytes, not Unicode code points.
 	println("Byte from myStr2[0]:", myStr2[0]) // Expected: E4 (byte value 228) - First byte of '你'
 	println("Byte from myStr2[1]:", myStr2[1]) // Expected: BD (byte value 189) - Second byte of '你'
 	println("Byte from myStr2[2]:", myStr2[2]) // Expected: A0 (byte value 160) - Third byte of '你'
 	println("Byte from myStr2[3]:", myStr2[3]) // Expected: E5 (byte value 229) - First byte of '好'
+
+	// Constant lookup tables preserve invalid UTF-8 and control bytes.
+	for i := 0; i < len(lookup); i++ {
+		println("constant byte", lookup[i])
+	}
+	checkBounds(-1)
+	checkBounds(len(lookup))
+}
+
+const lookup = "\x00\xff\a你"
+
+func checkBounds(index int) {
+	defer func() { println("out of bounds", recover() != nil) }()
+	println(lookup[index])
 }

--- a/tests/tests/string_index_access/string_index_access.gs.ts
+++ b/tests/tests/string_index_access/string_index_access.gs.ts
@@ -3,6 +3,8 @@
 
 import * as $ from "@goscript/builtin/index.js"
 
+export const lookup: string = $.bytesToString(new Uint8Array([0, 255, 7, 228, 189, 160]))
+
 export async function main(): globalThis.Promise<void> {
 	let myStr1 = "testing"
 	await $.println("Byte from myStr1[0]:", $.uint($.indexStringOrBytes(myStr1, 0), 8))
@@ -10,16 +12,34 @@ export async function main(): globalThis.Promise<void> {
 	await $.println("Byte from myStr1[6]:", $.uint($.indexStringOrBytes(myStr1, 6), 8))
 
 	let myStr2 = "你好世界"
-	// Accessing bytes of multi-byte characters
-	// '你' is E4 BD A0 in UTF-8
-	// '好' is E5 A5 BD in UTF-8
-	// '世' is E4 B8 96 in UTF-8
-	// '界' is E7 95 C2 8C in UTF-8 (界 seems to be E7 95 8C, let's assume 3 bytes for simplicity in this example)
-	// For "你好世界", bytes are: E4 BD A0 E5 A5 BD E4 B8 96 E7 95 8C
+	// String indexing returns UTF-8 bytes, not Unicode code points.
 	await $.println("Byte from myStr2[0]:", $.uint($.indexStringOrBytes(myStr2, 0), 8))
 	await $.println("Byte from myStr2[1]:", $.uint($.indexStringOrBytes(myStr2, 1), 8))
 	await $.println("Byte from myStr2[2]:", $.uint($.indexStringOrBytes(myStr2, 2), 8))
 	await $.println("Byte from myStr2[3]:", $.uint($.indexStringOrBytes(myStr2, 3), 8))
+
+	// Constant lookup tables preserve invalid UTF-8 and control bytes.
+	for (let i = 0; i < 6; i++) {
+		await $.println("constant byte", $.uint($.indexByteString("\x00\xff\x07\xe4\xbd\xa0", i), 8))
+	}
+	await checkBounds(-1)
+	await checkBounds(6)
+}
+
+export async function checkBounds(index: number): globalThis.Promise<void> {
+	const __defer = new $.AsyncDisposableStack()
+	try {
+		__defer.defer(async () => { await (async (): globalThis.Promise<void> => {
+			await $.println("out of bounds", $.recover() != null)
+		})() })
+		await $.println($.uint($.indexByteString("\x00\xff\x07\xe4\xbd\xa0", index), 8))
+		await __defer.dispose()
+	} catch (e) {
+		await __defer.disposePanic(e)
+		if (!$.recovered(e)) {
+			throw e
+		}
+	}
 }
 
 if ($.isMainScript(import.meta)) {


### PR DESCRIPTION
Avoid scanning existing entries on string-key misses and insertions. Binary and UTF-8 key representations retain Go equality, and map literals use the same runtime owner.

Constant string indexing now reads encoded bytes directly with bounds checks, avoiding repeated byte-buffer allocation in lookup tables.

Validated with focused compiler and compliance checks, 66 runtime tests, typecheck, and lint. Lint retains four existing warnings in generated protobuf files.
