### PR TITLE
perf(compiler): fuse inert byte slice copy ranges

### DIFF
--- a/compiler/lowering-copy.go
+++ b/compiler/lowering-copy.go
@@ -1,0 +1,74 @@
+package compiler
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+)
+
+// lowerByteCopyRanges fuses byte-slice operands whose evaluation cannot suspend,
+// mutate state, or panic before the runtime validates each slice in order.
+func (o *LoweringOwner) lowerByteCopyRanges(ctx lowerFileContext, expr *ast.CallExpr) (string, []Diagnostic, bool) {
+	if len(expr.Args) != 2 {
+		return "", nil, false
+	}
+
+	// Keep effectful operands in ordinary lowering so their slice checks remain
+	// interleaved with subsequent operand evaluation.
+	var ranges [2]*ast.SliceExpr
+	for index, arg := range expr.Args {
+		slice, ok := unwrapParenExpr(arg).(*ast.SliceExpr)
+		if !ok || slice.Slice3 || !isByteSliceType(ctx.semPkg.source.TypesInfo.TypeOf(slice.X)) ||
+			!copyRangeValueIsInert(ctx, slice.X) ||
+			!copyRangeValueIsInert(ctx, slice.Low) ||
+			!copyRangeValueIsInert(ctx, slice.High) {
+			return "", nil, false
+		}
+		ranges[index] = slice
+	}
+
+	// Pass the original slices and bounds directly, avoiding temporary views.
+	var args []string
+	var diagnostics []Diagnostic
+	for _, slice := range ranges {
+		target, targetDiagnostics := o.lowerExpr(ctx, slice.X)
+		low, lowDiagnostics := o.lowerOptionalExpr(ctx, slice.Low)
+		high, highDiagnostics := o.lowerOptionalExpr(ctx, slice.High)
+		args = append(args, target,
+			o.lowerNumberIndexValue(ctx, slice.Low, low),
+			o.lowerNumberIndexValue(ctx, slice.High, high))
+		diagnostics = append(diagnostics, targetDiagnostics...)
+		diagnostics = append(diagnostics, lowDiagnostics...)
+		diagnostics = append(diagnostics, highDiagnostics...)
+	}
+	return o.runtimeOwner.QualifiedHelper(RuntimeHelperCopyByteRanges) +
+		"(" + strings.Join(args, ", ") + ")", diagnostics, true
+}
+
+// copyRangeValueIsInert excludes operations that could expose a postponed slice
+// panic, including lazy package variable reads, calls, indexing, and division.
+func copyRangeValueIsInert(ctx lowerFileContext, expr ast.Expr) bool {
+	if expr == nil {
+		return true
+	}
+	if value, ok := ctx.semPkg.source.TypesInfo.Types[expr]; ok && value.Value != nil {
+		return true
+	}
+	switch expr := unwrapParenExpr(expr).(type) {
+	case *ast.Ident:
+		variable, ok := ctx.semPkg.source.TypesInfo.Uses[expr].(*types.Var)
+		return ok && (variable.Pkg() == nil || variable.Parent() != variable.Pkg().Scope())
+	case *ast.UnaryExpr:
+		switch expr.Op {
+		case token.ADD, token.SUB, token.XOR:
+			return copyRangeValueIsInert(ctx, expr.X)
+		}
+	case *ast.BinaryExpr:
+		switch expr.Op {
+		case token.ADD, token.SUB, token.MUL, token.AND, token.OR, token.XOR, token.AND_NOT:
+			return copyRangeValueIsInert(ctx, expr.X) && copyRangeValueIsInert(ctx, expr.Y)
+		}
+	}
+	return false
+}

--- a/compiler/lowering.go
+++ b/compiler/lowering.go
@@ -8332,6 +8332,10 @@ func (o *LoweringOwner) lowerCallExpr(ctx lowerFileContext, expr *ast.CallExpr) 
 			return o.lowerMakeExpr(ctx, expr)
 		case "new":
 			return o.lowerNewExpr(ctx, expr)
+		case "copy":
+			if call, diagnostics, ok := o.lowerByteCopyRanges(ctx, expr); ok {
+				return call, diagnostics
+			}
 		}
 	}
 	if targetType := typeFromExpr(ctx, expr.Fun); targetType != nil {

--- a/compiler/runtime-contract.go
+++ b/compiler/runtime-contract.go
@@ -103,6 +103,7 @@ const (
 	RuntimeHelperAppendZero                   RuntimeHelper = "slice.appendZero"
 	RuntimeHelperAppendZeros                  RuntimeHelper = "slice.appendZeros"
 	RuntimeHelperCopy                         RuntimeHelper = "slice.copy"
+	RuntimeHelperCopyByteRanges               RuntimeHelper = "slice.copyByteRanges"
 	RuntimeHelperAsArray                      RuntimeHelper = "slice.asArray"
 	RuntimeHelperStringToRunes                RuntimeHelper = "slice.stringToRunes"
 	RuntimeHelperRangeString                  RuntimeHelper = "slice.rangeString"
@@ -353,6 +354,7 @@ func runtimeHelperContracts() []RuntimeHelperContract {
 		runtimeHelper(RuntimeHelperAppendZero, "appendZero", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperAppendZeros, "appendZeros", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperCopy, "copy", RuntimeHelperCategorySlice),
+		runtimeHelper(RuntimeHelperCopyByteRanges, "copyByteRanges", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperAsArray, "asArray", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperStringToRunes, "stringToRunes", RuntimeHelperCategorySlice),
 		runtimeHelper(RuntimeHelperRangeString, "rangeString", RuntimeHelperCategorySlice),

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -128,7 +128,7 @@ Go's explicit error return values are maintained. Functions returning an error t
 *   `append()`: Mapped to `$.append()` runtime helper.
 *   `make()`: Mapped to runtime helper functions (`$.makeSlice()`, `$.makeMap()`, `$.makeChannel()`).
 *   `new()`: Mapped to `new T()`, returning a new instance of the zero value.
-*   `copy()`: Mapped to `$.copy()` runtime helper.
+*   `copy()`: Mapped to `$.copy()` runtime helper. When both operands are two-index byte-slice expressions with inert local values and bounds, the compiler emits `$.copyByteRanges()` to avoid temporary slice views. The runtime checks destination and source bounds before copying, preserves capacity and overlap behavior, and supports both typed and Array-backed byte slices. Calls, package-variable reads, and other potentially effectful operands retain ordinary slice evaluation.
 *   `delete()`: Mapped to `$.deleteMapEntry()` runtime helper.
 *   `close()`: Mapped to `channel.close()` method call.
 *   `panic()`: Mapped to `$.panic()` which throws an Error.
@@ -162,7 +162,7 @@ The runtime provides:
 
 *   Helper types (`$.GoError`, `$.Slice`, `$.Bytes`, `$.Channel`, `$.VarRef`, `$.DisposableStack`, `$.AsyncDisposableStack`, etc.).
 *   Helper functions:
-    *   Slice operations: `$.makeSlice`, `$.goSlice`, `$.append`, `$.copy`, `$.len`, `$.cap`, `$.clear`
+    *   Slice operations: `$.makeSlice`, `$.goSlice`, `$.append`, `$.copy`, `$.copyByteRanges`, `$.len`, `$.cap`, `$.clear`
     *   Map operations: `$.makeMap`, `$.mapGet`, `$.mapSet`, `$.deleteMapEntry`
     *   Channel operations: `$.makeChannel`, `$.chanSend`, `$.chanRecv`, `$.chanRecvWithOk`, `$.selectStatement`
     *   String operations include `$.indexString`, `$.stringLen`, `$.stringToRunes`, `$.stringToBytes`, and `$.bytesToString`. Length and byte indexing read ASCII strings directly without allocating an encoded byte array. Other strings retain UTF-8 byte access and the binary-string representation for invalid UTF-8; explicit string-to-byte conversion still creates independent storage.

--- a/gs/builtin/slice.test.ts
+++ b/gs/builtin/slice.test.ts
@@ -11,6 +11,7 @@ import {
   bytesFromHex,
   bytesToString,
   copy,
+  copyByteRanges,
   GoBinaryString,
   goSlice,
   indexString,
@@ -26,6 +27,49 @@ import {
   stringToBytes,
 } from './slice.js'
 import { markAsStructValue } from './type.js'
+
+describe('byte range copies', () => {
+  it('copies overlapping views of the same buffer with memmove semantics', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5])
+    const src = bytes.subarray(0, 4)
+    const dst = bytes.subarray(1)
+
+    expect(copyByteRanges(dst, 0, undefined, src, 0, undefined)).toBe(4)
+    expect(Array.from(bytes)).toEqual([1, 1, 2, 3, 4])
+    expect(copyByteRanges(bytes, 0, 4, bytes, 1, 5)).toBe(4)
+    expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 4])
+  })
+
+  it('uses metadata capacity while preserving omitted high bounds', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6])
+    const dst = goSlice(bytes, 1, 2, 5)
+    const src = new Uint8Array([7, 8, 9])
+
+    expect(copyByteRanges(dst, 1, 4, src, 0, undefined)).toBe(3)
+    expect(Array.from(bytes)).toEqual([1, 2, 7, 8, 9, 6])
+    expect(copyByteRanges(dst, undefined, undefined, src, 0, 3)).toBe(1)
+    expect(Array.from(bytes)).toEqual([1, 7, 7, 8, 9, 6])
+  })
+
+  it('validates both ranges before writing, including nil destinations', () => {
+    const dst = new Uint8Array([1, 2])
+    const src = new Uint8Array([3])
+
+    expect(() => copyByteRanges(dst, 0, 2, src, 0, 2)).toThrow()
+    expect(Array.from(dst)).toEqual([1, 2])
+    expect(() => copyByteRanges(null, 0, 0, src, 0, 2)).toThrow()
+    expect(copyByteRanges(null, 0, 0, src, 0, 1)).toBe(0)
+  })
+
+  it('preserves Array-backed byte slice aliases', () => {
+    const backing = [1, 2, 3, 4, 5]
+    const dst = goSlice(backing, 1, 4)
+    const src = goSlice(backing, 0, 3)
+
+    expect(copyByteRanges(dst, 0, 3, src, 0, 3)).toBe(3)
+    expect(backing).toEqual([1, 1, 2, 3, 5])
+  })
+})
 
 describe('compiler byte constants', () => {
   it('indexes encoded constants by byte with Go bounds checks', () => {

--- a/gs/builtin/slice.ts
+++ b/gs/builtin/slice.ts
@@ -362,6 +362,19 @@ function byteSliceMeta(slice: Uint8Array): ByteSliceMeta | undefined {
   return (slice as ByteSlice).__meta__
 }
 
+/** checkByteSliceBounds validates two-index slice bounds against capacity. */
+function checkByteSliceBounds(
+  low: number,
+  high: number,
+  capacity: number,
+): void {
+  if (low < 0 || high < low || low > capacity || high > capacity) {
+    runtimePanic(
+      `runtime error: slice bounds out of range [${low}:${high}] with capacity ${capacity}`,
+    )
+  }
+}
+
 function byteSliceView(
   backing: Uint8Array,
   offset: number,
@@ -617,16 +630,7 @@ export function goSlice<T>(
     const actualLow = low ?? 0
     const actualHigh = high ?? s.length
 
-    if (
-      actualLow < 0 ||
-      actualHigh < actualLow ||
-      actualLow > baseCapacity ||
-      actualHigh > baseCapacity
-    ) {
-      runtimePanic(
-        `runtime error: slice bounds out of range [${actualLow}:${actualHigh}] with capacity ${baseCapacity}`,
-      )
-    }
+    checkByteSliceBounds(actualLow, actualHigh, baseCapacity)
 
     const newLength = actualHigh - actualLow
 
@@ -1366,6 +1370,48 @@ export function copy<T>(
   }
 
   return copyBetweenSlices(dst as Slice<T>, src as Slice<T>, count)
+}
+
+/**
+ * copyByteRanges copies two sliced byte ranges after validating destination
+ * and source bounds in order. Callers evaluate only inert operands before entry.
+ * Omitted high bounds use length; explicit high bounds may reach capacity.
+ */
+export function copyByteRanges(
+  dst: Slice<number>,
+  dstLow: number | undefined,
+  dstHigh: number | undefined,
+  src: Slice<number>,
+  srcLow: number | undefined,
+  srcHigh: number | undefined,
+): number {
+  if (!(dst instanceof Uint8Array) || !(src instanceof Uint8Array)) {
+    return copy(goSlice(dst, dstLow, dstHigh), goSlice(src, srcLow, srcHigh))
+  }
+
+  const dstMeta = byteSliceMeta(dst)
+  const dstBacking = dstMeta?.backing ?? dst
+  const dstStart = normalizeSliceIndex(dstLow) ?? 0
+  const dstEnd = normalizeSliceIndex(dstHigh) ?? dst.length
+  checkByteSliceBounds(dstStart, dstEnd, dstMeta?.capacity ?? dst.length)
+
+  const srcMeta = byteSliceMeta(src)
+  const srcBacking = srcMeta?.backing ?? src
+  const srcStart = normalizeSliceIndex(srcLow) ?? 0
+  const srcEnd = normalizeSliceIndex(srcHigh) ?? src.length
+  checkByteSliceBounds(srcStart, srcEnd, srcMeta?.capacity ?? src.length)
+
+  const count = Math.min(dstEnd - dstStart, srcEnd - srcStart)
+  if (count === 0) return 0
+
+  const dstOffset = (dstMeta?.offset ?? 0) + dstStart
+  const srcOffset = (srcMeta?.offset ?? 0) + srcStart
+  if (dstBacking === srcBacking) {
+    dstBacking.copyWithin(dstOffset, srcOffset, srcOffset + count)
+  } else {
+    dstBacking.set(srcBacking.subarray(srcOffset, srcOffset + count), dstOffset)
+  }
+  return count
 }
 
 function copyFromString<T>(

--- a/tests/tests/slice_copy_overlap/expected.log
+++ b/tests/tests/slice_copy_overlap/expected.log
@@ -2,3 +2,12 @@ right count: 3
 right: 1 2 2 3 4
 left count: 3
 left: 1 3 4 5 5
+byte right: 3 1 2 2 3 4
+byte left: 3 2 3 4 3 4
+capacity: 3 10 11 7 8 9 15
+length: 1 7 7
+bound: 0
+bound: 1
+effect count: 1
+nil: 0
+invalid source: true

--- a/tests/tests/slice_copy_overlap/slice_copy_overlap.go
+++ b/tests/tests/slice_copy_overlap/slice_copy_overlap.go
@@ -1,6 +1,7 @@
 package main
 
 func main() {
+	// Integer slices retain overlapping memmove behavior.
 	right := []int{1, 2, 3, 4, 5}
 	n := copy(right[2:], right[1:4])
 	println("right count:", n)
@@ -10,4 +11,43 @@ func main() {
 	n = copy(left[1:], left[2:])
 	println("left count:", n)
 	println("left:", left[0], left[1], left[2], left[3], left[4])
+
+	// Byte ranges copy in both directions without exposing temporary views.
+	bytes := []byte{1, 2, 3, 4, 5}
+	start, stop := 1, 4
+	n = copy(bytes[start+1:], bytes[start:stop])
+	println("byte right:", n, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
+	n = copy(bytes[:stop-1], bytes[start+1:])
+	println("byte left:", n, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
+
+	// Explicit high bounds may extend into spare capacity; omitted highs may not.
+	backing := []byte{10, 11, 12, 13, 14, 15}
+	dst := backing[1:2:5]
+	src := []byte{7, 8, 9}
+	n = copy(dst[1:4], src[:])
+	println("capacity:", n, backing[0], backing[1], backing[2], backing[3], backing[4], backing[5])
+	n = copy(dst[:], src[:])
+	println("length:", n, backing[1], backing[2])
+
+	// Bounds with calls preserve their observable evaluation sequence.
+	n = copy(dst[bound(0):], src[bound(1):])
+	println("effect count:", n)
+
+	// Nil ranges still validate the other operand before returning zero.
+	var empty []byte
+	println("nil:", copy(empty[:], src[:]))
+	checkInvalidSource(empty, src)
+}
+
+// bound prints each bound evaluation and returns its value.
+func bound(value int) int {
+	println("bound:", value)
+	return value
+}
+
+// checkInvalidSource verifies a source bounds panic even for an empty destination.
+func checkInvalidSource(dst, src []byte) {
+	defer func() { println("invalid source:", recover() != nil) }()
+	high := len(src) + 1
+	copy(dst[:], src[:high])
 }

--- a/tests/tests/slice_copy_overlap/slice_copy_overlap.gs.ts
+++ b/tests/tests/slice_copy_overlap/slice_copy_overlap.gs.ts
@@ -4,6 +4,7 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export async function main(): globalThis.Promise<void> {
+	// Integer slices retain overlapping memmove behavior.
 	let right: $.Slice<number> = $.arrayToSlice<number>([1, 2, 3, 4, 5])
 	let n = $.copy($.goSlice(right, 2, undefined), $.goSlice(right, 1, 4))
 	await $.println("right count:", n)
@@ -13,6 +14,55 @@ export async function main(): globalThis.Promise<void> {
 	n = $.copy($.goSlice(left, 1, undefined), $.goSlice(left, 2, undefined))
 	await $.println("left count:", n)
 	await $.println("left:", $.arrayIndex(left!, 0), $.arrayIndex(left!, 1), $.arrayIndex(left!, 2), $.arrayIndex(left!, 3), $.arrayIndex(left!, 4))
+
+	// Byte ranges copy in both directions without exposing temporary views.
+	let bytes: $.Slice<number> = new Uint8Array([1, 2, 3, 4, 5]) as $.Slice<number>
+	let start = 1
+	let stop = 4
+	n = $.copyByteRanges(bytes, start + 1, undefined, bytes, start, stop)
+	await $.println("byte right:", n, $.uint($.arrayIndex(bytes!, 0), 8), $.uint($.arrayIndex(bytes!, 1), 8), $.uint($.arrayIndex(bytes!, 2), 8), $.uint($.arrayIndex(bytes!, 3), 8), $.uint($.arrayIndex(bytes!, 4), 8))
+	n = $.copyByteRanges(bytes, undefined, stop - 1, bytes, start + 1, undefined)
+	await $.println("byte left:", n, $.uint($.arrayIndex(bytes!, 0), 8), $.uint($.arrayIndex(bytes!, 1), 8), $.uint($.arrayIndex(bytes!, 2), 8), $.uint($.arrayIndex(bytes!, 3), 8), $.uint($.arrayIndex(bytes!, 4), 8))
+
+	// Explicit high bounds may extend into spare capacity; omitted highs may not.
+	let backing: $.Slice<number> = new Uint8Array([10, 11, 12, 13, 14, 15]) as $.Slice<number>
+	let dst: $.Slice<number> = $.goSlice(backing, 1, 2, 5)
+	let src: $.Slice<number> = new Uint8Array([7, 8, 9]) as $.Slice<number>
+	n = $.copyByteRanges(dst, 1, 4, src, undefined, undefined)
+	await $.println("capacity:", n, $.uint($.arrayIndex(backing!, 0), 8), $.uint($.arrayIndex(backing!, 1), 8), $.uint($.arrayIndex(backing!, 2), 8), $.uint($.arrayIndex(backing!, 3), 8), $.uint($.arrayIndex(backing!, 4), 8), $.uint($.arrayIndex(backing!, 5), 8))
+	n = $.copyByteRanges(dst, undefined, undefined, src, undefined, undefined)
+	await $.println("length:", n, $.uint($.arrayIndex(backing!, 1), 8), $.uint($.arrayIndex(backing!, 2), 8))
+
+	// Bounds with calls preserve their observable evaluation sequence.
+	n = $.copy($.goSlice(dst, await bound(0), undefined), $.goSlice(src, await bound(1), undefined))
+	await $.println("effect count:", n)
+
+	// Nil ranges still validate the other operand before returning zero.
+	let empty: $.Slice<number> = null! as $.Slice<number>
+	await $.println("nil:", $.copyByteRanges(empty, undefined, undefined, src, undefined, undefined))
+	await checkInvalidSource(empty, src)
+}
+
+export async function bound(value: number): globalThis.Promise<number> {
+	await $.println("bound:", value)
+	return value
+}
+
+export async function checkInvalidSource(dst: $.Slice<number>, src: $.Slice<number>): globalThis.Promise<void> {
+	const __defer = new $.AsyncDisposableStack()
+	try {
+		__defer.defer(async () => { await (async (): globalThis.Promise<void> => {
+			await $.println("invalid source:", $.recover() != null)
+		})() })
+		let high = $.len(src) + 1
+		$.copyByteRanges(dst, undefined, undefined, src, undefined, high)
+		await __defer.dispose()
+	} catch (e) {
+		await __defer.disposePanic(e)
+		if (!$.recovered(e)) {
+			throw e
+		}
+	}
 }
 
 if ($.isMainScript(import.meta)) {


### PR DESCRIPTION
Byte-slice copy calls with inert two-index operands now pass their backing slices and bounds directly to the runtime, avoiding temporary slice views. Calls and other effectful operands retain ordinary evaluation. The runtime preserves bounds-check order, spare capacity, nil handling, return counts, and overlapping copies.

Validated with 37 slice tests, the generated Go overlap compliance fixture, TypeScript checking, and lint. Earlier same-input decoder measurements reduced literal-copy time by about half; the complete startup samples overlapped, so this change claims reduced copy overhead without a precise startup speedup.
