### PR TITLE
fix(runtime): claim blocked select cases atomically

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -1025,6 +1025,8 @@ The `selectStatement` helper takes an array of case objects, each containing:
 
 For receive operations, the callback receives a `result` object with `value` and `ok` properties, similar to Go's comma-ok syntax. The second parameter to `selectStatement` indicates whether the `select` has a default case.
 
+Blocked cases claim selection synchronously when the channel transfers a value, before Promise continuations run. Claiming cancels the other registered cases, so a losing receive cannot consume a value and a losing send cannot remain available to another receiver. Send and receive cases in the same select never rendezvous with each other.
+
 ## Control Flow: `if` Statements
 
 Go's `if` statements are translated into standard TypeScript `if` statements.

--- a/gs/builtin/channel.ts
+++ b/gs/builtin/channel.ts
@@ -31,10 +31,8 @@ function completeUnbufferedReceive<T>(
   value: T,
 ): Promise<void> {
   return new Promise<void>((resolve) => {
-    queueMicrotask(() => {
-      resolveReceive(value)
-      queueMicrotask(resolve)
-    })
+    resolveReceive(value)
+    queueMicrotask(resolve)
   })
 }
 
@@ -43,10 +41,8 @@ function completeUnbufferedReceiveWithOk<T>(
   result: ChannelReceiveResult<T>,
 ): Promise<void> {
   return new Promise<void>((resolve) => {
-    queueMicrotask(() => {
-      resolveReceive(result)
-      queueMicrotask(resolve)
-    })
+    resolveReceive(result)
+    queueMicrotask(resolve)
   })
 }
 
@@ -88,13 +84,19 @@ export interface Channel<T> {
 
   /**
    * Used in select statements to create a receive operation promise.
+   * Calls onCommit synchronously at selection to withdraw the other cases.
    * @param id An identifier for this case in the select statement
    * @returns Promise that resolves when this case is selected
    */
-  selectReceive(id: number, signal?: AbortSignal): Promise<SelectResult<T>>
+  selectReceive(
+    id: number,
+    signal?: AbortSignal,
+    onCommit?: () => void,
+  ): Promise<SelectResult<T>>
 
   /**
    * Used in select statements to create a send operation promise.
+   * Calls onCommit synchronously at selection to withdraw the other cases.
    * @param value The value to send
    * @param id An identifier for this case in the select statement
    * @returns Promise that resolves when this case is selected
@@ -103,6 +105,7 @@ export interface Channel<T> {
     value: T,
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<boolean>>
 
   /**
@@ -268,7 +271,7 @@ export async function selectStatement<T, V = void>(
   }
 
   // 3. If no operations are ready and no default case, block until one is ready
-  // Use Promise.race on the blocking promises
+  // Claim at the channel operation before another branch can consume a value.
   const abort = new AbortController()
   const blockingPromises = cases
     .filter((c) => c.id !== -1) // Exclude default case
@@ -280,9 +283,12 @@ export async function selectStatement<T, V = void>(
           caseObj.value,
           caseObj.id,
           abort.signal,
+          () => abort.abort(),
         )
       } else {
-        return caseObj.channel!.selectReceive(caseObj.id, abort.signal)
+        return caseObj.channel!.selectReceive(caseObj.id, abort.signal, () =>
+          abort.abort(),
+        )
       }
     })
 
@@ -405,6 +411,7 @@ class BufferedChannel<T> implements Channel<T> {
     value: T
     resolveSend: () => void
     rejectSend: (e: Error) => void
+    signal?: AbortSignal
   }> = []
 
   // Receivers queue for receive(): stores { resolve for receive, reject for receive }
@@ -416,6 +423,7 @@ class BufferedChannel<T> implements Channel<T> {
   // Receivers queue for receiveWithOk(): stores { resolve for receiveWithOk }
   private receiversWithOk: Array<{
     resolveReceive: (result: ChannelReceiveResult<T>) => void
+    signal?: AbortSignal
   }> = []
 
   constructor(capacity: number, zeroValue: T) {
@@ -464,7 +472,7 @@ class BufferedChannel<T> implements Channel<T> {
       if (this.senders.length > 0) {
         const senderTask = this.senders.shift()!
         this.buffer.push(senderTask.value) // Sender's value now goes into buffer
-        queueMicrotask(() => senderTask.resolveSend()) // Unblock sender
+        senderTask.resolveSend() // Unblock sender
       }
       return value
     }
@@ -479,7 +487,7 @@ class BufferedChannel<T> implements Channel<T> {
     // Attempt to rendezvous with a waiting sender.
     if (this.senders.length > 0) {
       const senderTask = this.senders.shift()!
-      queueMicrotask(() => senderTask.resolveSend()) // Unblock the sender
+      senderTask.resolveSend() // Unblock the sender
       return senderTask.value // Return the value from sender
     }
 
@@ -496,7 +504,7 @@ class BufferedChannel<T> implements Channel<T> {
       if (this.senders.length > 0) {
         const senderTask = this.senders.shift()!
         this.buffer.push(senderTask.value)
-        queueMicrotask(() => senderTask.resolveSend())
+        senderTask.resolveSend()
       }
       return { value, ok: true }
     }
@@ -505,7 +513,7 @@ class BufferedChannel<T> implements Channel<T> {
     // Attempt to rendezvous with a waiting sender.
     if (this.senders.length > 0) {
       const senderTask = this.senders.shift()!
-      queueMicrotask(() => senderTask.resolveSend())
+      senderTask.resolveSend()
       return { value: senderTask.value, ok: true }
     }
 
@@ -527,14 +535,14 @@ class BufferedChannel<T> implements Channel<T> {
       if (this.senders.length > 0) {
         const senderTask = this.senders.shift()!
         this.buffer.push(senderTask.value)
-        queueMicrotask(() => senderTask.resolveSend())
+        senderTask.resolveSend()
       }
       return { value, ok: true, id }
     }
 
     if (this.senders.length > 0) {
       const senderTask = this.senders.shift()!
-      queueMicrotask(() => senderTask.resolveSend())
+      senderTask.resolveSend()
       return { value: senderTask.value, ok: true, id }
     }
 
@@ -547,24 +555,32 @@ class BufferedChannel<T> implements Channel<T> {
   async selectReceive(
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<T>> {
+    if (signal?.aborted) return new Promise(() => {})
     if (this.buffer.length > 0) {
+      onCommit?.()
       const value = this.buffer.shift()!
       if (this.senders.length > 0) {
         const senderTask = this.senders.shift()!
         this.buffer.push(senderTask.value)
-        queueMicrotask(() => senderTask.resolveSend())
+        senderTask.resolveSend()
       }
       return { value, ok: true, id }
     }
 
-    if (this.senders.length > 0) {
-      const senderTask = this.senders.shift()!
-      queueMicrotask(() => senderTask.resolveSend())
+    const senderIndex = this.senders.findIndex(
+      (sender) => !signal || sender.signal !== signal,
+    )
+    if (senderIndex >= 0) {
+      const senderTask = this.senders.splice(senderIndex, 1)[0]
+      onCommit?.()
+      senderTask.resolveSend()
       return { value: senderTask.value, ok: true, id }
     }
 
     if (this.closed) {
+      onCommit?.()
       return { value: this.zeroValue, ok: false, id }
     }
 
@@ -572,10 +588,12 @@ class BufferedChannel<T> implements Channel<T> {
       const state = { done: false }
       const receiversWithOk = this.receiversWithOk
       const task = {
+        signal,
         resolveReceive: (result: ChannelReceiveResult<T>) => {
           if (!state.done) {
             state.done = true
             cleanup()
+            onCommit?.()
             resolve({ ...result, id })
           }
         },
@@ -631,8 +649,11 @@ class BufferedChannel<T> implements Channel<T> {
     value: T,
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<boolean>> {
+    if (signal?.aborted) return new Promise(() => {})
     if (this.closed) {
+      onCommit?.()
       // A select case sending on a closed channel panics in Go.
       // This will cause Promise.race in selectStatement to reject.
       throw new Error('send on closed channel')
@@ -640,11 +661,16 @@ class BufferedChannel<T> implements Channel<T> {
 
     if (this.receivers.length > 0) {
       const receiverTask = this.receivers.shift()!
+      onCommit?.()
       await completeUnbufferedReceive(receiverTask.resolveReceive, value)
       return { value: true, ok: true, id }
     }
-    if (this.receiversWithOk.length > 0) {
-      const receiverTask = this.receiversWithOk.shift()!
+    const receiverIndex = this.receiversWithOk.findIndex(
+      (receiver) => !signal || receiver.signal !== signal,
+    )
+    if (receiverIndex >= 0) {
+      const receiverTask = this.receiversWithOk.splice(receiverIndex, 1)[0]
+      onCommit?.()
       await completeUnbufferedReceiveWithOk(receiverTask.resolveReceive, {
         value,
         ok: true,
@@ -653,6 +679,7 @@ class BufferedChannel<T> implements Channel<T> {
     }
 
     if (this.buffer.length < this.capacity) {
+      onCommit?.()
       this.buffer.push(value)
       return { value: true, ok: true, id }
     }
@@ -661,11 +688,13 @@ class BufferedChannel<T> implements Channel<T> {
       const state = { done: false }
       const senders = this.senders
       const task = {
+        signal,
         value,
         resolveSend: () => {
           if (!state.done) {
             state.done = true
             cleanup()
+            onCommit?.()
             resolve({ value: true, ok: true, id })
           }
         },
@@ -673,6 +702,7 @@ class BufferedChannel<T> implements Channel<T> {
           if (!state.done) {
             state.done = true
             cleanup()
+            onCommit?.()
             reject(e)
           }
         },
@@ -778,8 +808,13 @@ export interface ChannelRef<T> {
     value: T,
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<boolean>>
-  selectReceive(id: number, signal?: AbortSignal): Promise<SelectResult<T>>
+  selectReceive(
+    id: number,
+    signal?: AbortSignal,
+    onCommit?: () => void,
+  ): Promise<SelectResult<T>>
   trySelectReceive(id: number): SelectResult<T> | undefined
   trySelectSend(value: T, id: number): SelectResult<boolean> | undefined
   len(): number
@@ -823,12 +858,17 @@ export class BidirectionalChannelRef<T> implements ChannelRef<T> {
     value: T,
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<boolean>> {
-    return this.channel.selectSend(value, id, signal)
+    return this.channel.selectSend(value, id, signal, onCommit)
   }
 
-  selectReceive(id: number, signal?: AbortSignal): Promise<SelectResult<T>> {
-    return this.channel.selectReceive(id, signal)
+  selectReceive(
+    id: number,
+    signal?: AbortSignal,
+    onCommit?: () => void,
+  ): Promise<SelectResult<T>> {
+    return this.channel.selectReceive(id, signal, onCommit)
   }
 
   trySelectReceive(id: number): SelectResult<T> | undefined {
@@ -874,8 +914,9 @@ export class SendOnlyChannelRef<T> implements ChannelRef<T> {
     value: T,
     id: number,
     signal?: AbortSignal,
+    onCommit?: () => void,
   ): Promise<SelectResult<boolean>> {
-    return this.channel.selectSend(value, id, signal)
+    return this.channel.selectSend(value, id, signal, onCommit)
   }
 
   trySelectReceive(_id: number): SelectResult<T> | undefined {
@@ -899,7 +940,11 @@ export class SendOnlyChannelRef<T> implements ChannelRef<T> {
     return false
   }
 
-  selectReceive(_id: number, _signal?: AbortSignal): Promise<SelectResult<T>> {
+  selectReceive(
+    _id: number,
+    _signal?: AbortSignal,
+    _onCommit?: () => void,
+  ): Promise<SelectResult<T>> {
     throw new Error('Cannot receive from send-only channel')
   }
 
@@ -933,8 +978,12 @@ export class ReceiveOnlyChannelRef<T> implements ChannelRef<T> {
     return this.channel.canReceiveNonBlocking()
   }
 
-  selectReceive(id: number, signal?: AbortSignal): Promise<SelectResult<T>> {
-    return this.channel.selectReceive(id, signal)
+  selectReceive(
+    id: number,
+    signal?: AbortSignal,
+    onCommit?: () => void,
+  ): Promise<SelectResult<T>> {
+    return this.channel.selectReceive(id, signal, onCommit)
   }
 
   trySelectReceive(id: number): SelectResult<T> | undefined {

--- a/gs/builtin/runtime-contract.test.ts
+++ b/gs/builtin/runtime-contract.test.ts
@@ -1209,6 +1209,61 @@ describe('builtin runtime contract helpers', () => {
     expect(events).toEqual(['queued', 'receiver'])
   })
 
+  it('preserves values offered to losing select branches in the same turn', async () => {
+    const first = makeChannel(1, 0)
+    const second = makeChannel(1, 0)
+    const selected = selectStatement<number, number>([
+      {
+        id: 0,
+        isSend: false,
+        channel: first,
+        onSelected: (result) => result.value,
+      },
+      {
+        id: 1,
+        isSend: false,
+        channel: second,
+        onSelected: (result) => result.value,
+      },
+    ])
+
+    const firstSend = first.send(7)
+    const secondSend = second.send(9)
+    expect(await selected).toEqual([true, 7])
+    await Promise.all([firstSend, secondSend])
+    expect(second.len()).toBe(1)
+    expect(await second.receive()).toBe(9)
+  })
+
+  it('withdraws losing sends before another receiver can consume them', async () => {
+    const first = makeChannel(0, 0)
+    const second = makeChannel(0, 0)
+    const selected = selectStatement<number, number>([
+      { id: 0, isSend: true, channel: first, value: 7, onSelected: () => 0 },
+      { id: 1, isSend: true, channel: second, value: 9, onSelected: () => 1 },
+    ])
+
+    const received = first.receive()
+    expect(second.canReceiveNonBlocking()).toBe(false)
+    expect(await received).toBe(7)
+    expect(await selected).toEqual([true, 0])
+  })
+
+  it('never pairs send and receive branches of the same select', async () => {
+    const channel = makeChannel(0, 0)
+    const selected = selectStatement<number, number>([
+      { id: 0, isSend: false, channel, onSelected: (result) => result.value },
+      { id: 1, isSend: true, channel, value: 7, onSelected: () => -1 },
+    ])
+    const externalSend = channel.send(9)
+    try {
+      expect(await selected).toEqual([true, 9])
+    } finally {
+      channel.close()
+      await externalSend.catch(() => {})
+    }
+  })
+
   it('cancels losing select receive cases', async () => {
     const signal = makeChannel<string>(1, '', 'both')
     const timeout = makeChannel<string>(0, '', 'both')

--- a/tests/tests/select_statement/expected.log
+++ b/tests/tests/select_statement/expected.log
@@ -8,3 +8,4 @@ TEST7: Selected ch4 correctly: from ch4
 TEST8: Selected ch5 correctly: from ch5
 TEST9: Channel is closed, ok is false, val: false
 TEST10: Empty cases completed: 23 0
+TEST11: Concurrent select values preserved

--- a/tests/tests/select_statement/select_statement.go
+++ b/tests/tests/select_statement/select_statement.go
@@ -137,4 +137,38 @@ func main() {
 	case <-empty:
 	}
 	println("TEST10: Empty cases completed:", value, len(empty))
+
+	// Each blocked select consumes exactly one of two concurrent sends.
+	for range 16 {
+		first, second := make(chan int, 1), make(chan int, 1)
+		sent := make(chan struct{}, 2)
+		go func() {
+			first <- 7
+			sent <- struct{}{}
+		}()
+		go func() {
+			second <- 9
+			sent <- struct{}{}
+		}()
+		total := 0
+		select {
+		case total = <-first:
+		case total = <-second:
+		}
+		<-sent
+		<-sent
+		if len(first)+len(second) != 1 {
+			panic("select consumed an unselected value")
+		}
+		select {
+		case remaining := <-first:
+			total += remaining
+		case remaining := <-second:
+			total += remaining
+		}
+		if total != 16 {
+			panic("select lost a value")
+		}
+	}
+	println("TEST11: Concurrent select values preserved")
 }

--- a/tests/tests/select_statement/select_statement.gs.ts
+++ b/tests/tests/select_statement/select_statement.gs.ts
@@ -330,6 +330,75 @@ export async function main(): globalThis.Promise<void> {
 		return __goscriptSelect12Value
 	}
 	await $.println("TEST10: Empty cases completed:", value, $.len(empty))
+
+	// Each blocked select consumes exactly one of two concurrent sends.
+	for (let __rangeIndex = 0; __rangeIndex < 16; __rangeIndex++) {
+		let first: $.Channel<number> | null = $.makeChannel<number>(1, 0, "both")
+		let second: $.Channel<number> | null = $.makeChannel<number>(1, 0, "both")
+		let sent: $.Channel<{}> | null = $.makeChannel<{}>(2, {}, "both")
+		queueMicrotask(async () => { await (async (): globalThis.Promise<void> => {
+			await $.chanSend(first, 7)
+			await $.chanSend(sent, {})
+		})() })
+		queueMicrotask(async () => { await (async (): globalThis.Promise<void> => {
+			await $.chanSend(second, 9)
+			await $.chanSend(sent, {})
+		})() })
+		let total = 0
+		const [__goscriptSelect13HasReturn, __goscriptSelect13Value] = await $.selectStatement<any, void>([
+			{
+				id: 0,
+				isSend: false,
+				channel: first,
+				onSelected: async (__goscriptSelect13Result) => {
+					total = __goscriptSelect13Result.value
+				}
+			},
+			{
+				id: 1,
+				isSend: false,
+				channel: second,
+				onSelected: async (__goscriptSelect13Result) => {
+					total = __goscriptSelect13Result.value
+				}
+			}
+		], false)
+		if (__goscriptSelect13HasReturn) {
+			return __goscriptSelect13Value
+		}
+		await $.chanRecv(sent)
+		await $.chanRecv(sent)
+		if (($.len(first) + $.len(second)) != 1) {
+			$.panic("select consumed an unselected value")
+		}
+		const [__goscriptSelect14HasReturn, __goscriptSelect14Value] = await $.selectStatement<any, void>([
+			{
+				id: 0,
+				isSend: false,
+				channel: first,
+				onSelected: async (__goscriptSelect14Result) => {
+					let remaining = __goscriptSelect14Result.value
+					total = total + (remaining)
+				}
+			},
+			{
+				id: 1,
+				isSend: false,
+				channel: second,
+				onSelected: async (__goscriptSelect14Result) => {
+					let remaining = __goscriptSelect14Result.value
+					total = total + (remaining)
+				}
+			}
+		], false)
+		if (__goscriptSelect14HasReturn) {
+			return __goscriptSelect14Value
+		}
+		if (total != 16) {
+			$.panic("select lost a value")
+		}
+	}
+	await $.println("TEST11: Concurrent select values preserved")
 }
 
 if ($.isMainScript(import.meta)) {


### PR DESCRIPTION
Blocked select branches could consume multiple channel values before Promise.race chose a winner. Claim selection synchronously at channel transfer, cancel losing cases before further transfers, and prevent a select from rendezvousing with itself.

Validation: 33 runtime contract tests, compiled select compliance fixture, TypeScript typecheck, and JavaScript lint pass. The formerly intermittent downstream WebKit recovery test passes 50 repetitions in Chromium and WebKit. Go lint could not read the installed Go 1.27 export format; its binary supports an older format.