### PR TITLE
perf(protobuf): share generated forwarding methods

### DIFF
--- a/compiler/protobuf-ts-binding.go
+++ b/compiler/protobuf-ts-binding.go
@@ -652,14 +652,17 @@ func protobufTypeScriptBindingReplacesMethodName(name string) bool {
 	switch name {
 	case "CloneMessageVT",
 		"CloneVT",
+		"EqualMessageVT",
 		"EqualVT",
 		"MarshalJSON",
 		"MarshalProtoJSON",
 		"MarshalToSizedBufferVT",
+		"MarshalToVT",
 		"MarshalVT",
 		"ProtoMessage",
 		"Reset",
 		"SizeVT",
+		"String",
 		"UnmarshalJSON",
 		"UnmarshalProtoJSON",
 		"UnmarshalVT":

--- a/compiler/protobuf-ts-binding_test.go
+++ b/compiler/protobuf-ts-binding_test.go
@@ -125,6 +125,12 @@ func (x *Foo) EqualVT(other *Foo) bool {
 	return other != nil && x.Name == other.Name
 }
 
+func (x *Foo) EqualMessageVT(other any) bool {
+	println("inline EqualMessageVT marker")
+	value, ok := other.(*Foo)
+	return ok && x.EqualVT(value)
+}
+
 func (x *Foo) MarshalVT() ([]byte, error) {
 	println("inline MarshalVT marker")
 	return []byte(x.Name), nil
@@ -133,6 +139,20 @@ func (x *Foo) MarshalVT() ([]byte, error) {
 func (x *Foo) MarshalToSizedBufferVT(data []byte) (int, error) {
 	println("inline MarshalToSizedBufferVT marker")
 	return copy(data, x.Name), nil
+}
+
+func (x *Foo) MarshalToVT(data []byte) (int, error) {
+	println("inline MarshalToVT marker")
+	return x.MarshalToSizedBufferVT(data[:x.SizeVT()])
+}
+
+func (x *Foo) MarshalProtoText() string {
+	return "custom text"
+}
+
+func (x *Foo) String() string {
+	println("inline String marker")
+	return x.MarshalProtoText()
 }
 
 func (x *Foo) SizeVT() int {
@@ -174,7 +194,7 @@ export const Foo = {} as any
 	wantSnippets := []string{
 		`public declare CloneMessageVT: () => protobuf_go_lite.CloneMessage | null`,
 		`public declare MarshalVT: () => [$.Slice<number>, $.GoError]`,
-		`protobuf_go_lite.BindMessageMethods(this, "*protobufbindingmethods.Foo", ["CloneMessageVT", "CloneVT", "EqualVT", "MarshalToSizedBufferVT", "MarshalVT", "Reset", "SizeVT", "UnmarshalVT"])`,
+		`protobuf_go_lite.BindMessageMethods(this, "*protobufbindingmethods.Foo", ["CloneMessageVT", "CloneVT", "EqualMessageVT", "EqualVT", "MarshalToSizedBufferVT", "MarshalToVT", "MarshalVT", "Reset", "SizeVT", "String", "UnmarshalVT"])`,
 	}
 	for _, snippet := range wantSnippets {
 		if !strings.Contains(binding, snippet) {

--- a/gs/github.com/aperturerobotics/protobuf-go-lite/index.test.ts
+++ b/gs/github.com/aperturerobotics/protobuf-go-lite/index.test.ts
@@ -1137,18 +1137,67 @@ describe('generated method installation', () => {
         toBinary: () => new Uint8Array([7]),
       }
       declare MarshalVT: () => [$.Slice<number>, $.GoError]
+      declare MarshalToVT: (data: $.Slice<number>) => [number, $.GoError]
+      declare EqualMessageVT: (other: any) => boolean
+      declare String: () => string
+
+      EqualVT(other: Installed | null) {
+        return this === other
+      }
+
+      SizeVT() {
+        return 2
+      }
+
+      MarshalToSizedBufferVT(data: $.Slice<number>): [number, $.GoError] {
+        expect($.len(data)).toBe(2)
+        data![0] = 7
+        data![1] = 8
+        return [2, null]
+      }
+
+      MarshalProtoText() {
+        return 'custom text'
+      }
+
       MarshalJSON() {
         return 'custom'
       }
     }
-    BindMessageMethods(Installed, '*test.Installed', ['MarshalVT'])
+    BindMessageMethods(Installed, '*test.Installed', [
+      'EqualMessageVT',
+      'MarshalToVT',
+      'MarshalVT',
+      'String',
+    ])
     for (const receiver of [null, {}, new Installed()]) {
       const [data, err] = Installed.prototype.MarshalVT.call(
         receiver as Installed,
       )
       expect(err).toBeNull()
       expect(Array.from(data ?? [])).toEqual([7])
+
+      const buffer = new Uint8Array([0, 0, 99, 99])
+      expect(
+        Installed.prototype.MarshalToVT.call(receiver as Installed, buffer),
+      ).toEqual([2, null])
+      expect(Array.from(buffer)).toEqual([7, 8, 99, 99])
+      expect(Installed.prototype.String.call(receiver as Installed)).toBe(
+        'custom text',
+      )
     }
+    const instance = new Installed()
+    const boxed = $.interfaceValue(instance, '*test.Installed')
+    expect(instance.EqualMessageVT(boxed)).toBe(true)
+    expect(new Installed().EqualMessageVT(boxed)).toBe(false)
+    expect(instance.EqualMessageVT({})).toBe(false)
+    expect(instance.EqualMessageVT(null)).toBe(false)
+    expect(
+      Installed.prototype.EqualMessageVT.call(
+        null as any,
+        $.interfaceValue(null, '*test.Installed'),
+      ),
+    ).toBe(true)
     expect(new Installed().MarshalJSON()).toBe('custom')
     expect(Object.keys(new Installed())).not.toContain('MarshalVT')
     expect(

--- a/gs/github.com/aperturerobotics/protobuf-go-lite/index.ts
+++ b/gs/github.com/aperturerobotics/protobuf-go-lite/index.ts
@@ -418,6 +418,7 @@ type BoundFieldInfo = {
 
 type BoundMessageCtor<T = any> = {
   new (init?: any): T
+  readonly prototype: T
   __protobufTypeScriptFields?: Record<string, BoundMessageCtor>
   __protobufTypeScriptOneofFields?: Record<
     string,
@@ -714,6 +715,13 @@ function boundMessageMethods(ctor: BoundMessageCtor, typeName: string) {
     CloneVT(this: any) {
       return CloneBoundMessage(ctor, this)
     },
+    EqualMessageVT(this: any, other: any) {
+      const [value, ok] = $.typeAssertTuple(other, {
+        kind: $.TypeKind.Pointer,
+        elemType: typeName.slice(1),
+      })
+      return ok && ctor.prototype.EqualVT.call(this, value)
+    },
     EqualVT(this: any, other: any) {
       return EqualBoundMessage(ctor, this, other)
     },
@@ -722,6 +730,13 @@ function boundMessageMethods(ctor: BoundMessageCtor, typeName: string) {
     },
     MarshalToSizedBufferVT(this: any, data: $.Slice<number>) {
       return MarshalBoundMessageToSizedBufferVT(ctor, this, data)
+    },
+    MarshalToVT(this: any, data: $.Slice<number>) {
+      const size = ctor.prototype.SizeVT.call(this)
+      return ctor.prototype.MarshalToSizedBufferVT.call(
+        this,
+        $.goSlice(data, undefined, size),
+      )
     },
     SizeVT(this: any) {
       return SizeBoundMessageVT(ctor, this)
@@ -750,6 +765,9 @@ function boundMessageMethods(ctor: BoundMessageCtor, typeName: string) {
     ProtoMessage() {},
     Reset(this: any) {
       $.assignStruct($.pointerValue(this), $.markAsStructValue(new ctor()))
+    },
+    String(this: any) {
+      return ctor.prototype.MarshalProtoText.call(this)
     },
   }
 }


### PR DESCRIPTION
Generate prototype declarations for protobuf interface equality, buffer marshaling, and String methods, and install their implementations through the shared binding runtime. Keep dispatch on the declaring constructor so nil and borrowed receivers behave consistently and handwritten methods remain in use.

The binding compiler check, runtime tests, TypeScript check, and fresh Chromium Drive storage scenario pass. The minified core bundle is 645,901 bytes smaller.
