### PR TITLE
perf(compiler): compact reflected method metadata

### DIFF
--- a/compiler/compiler-cache.go
+++ b/compiler/compiler-cache.go
@@ -27,7 +27,7 @@ const compilerCacheSchema = "goscript-package-artifact-v1"
 // compilerSemanticsVersion versions emitted-output semantics. Bump this value
 // with every behavior-changing compiler commit so artifacts cached by an
 // older binary miss and rebuild instead of replaying stale bytes.
-const compilerSemanticsVersion = "5"
+const compilerSemanticsVersion = "6"
 
 type compilerCacheEntryKind string
 

--- a/compiler/lowering.go
+++ b/compiler/lowering.go
@@ -3184,13 +3184,18 @@ func (o *LoweringOwner) runtimeMethodAssertSignaturesWithSeen(ctx lowerFileConte
 }
 
 func (o *LoweringOwner) runtimeMethodSignature(method *types.Func, seen map[types.Type]bool) string {
+	helper := o.runtimeOwner.QualifiedHelper(RuntimeHelperMethodSignature)
+	args := []string{strconv.Quote(method.Name())}
 	signature, _ := method.Type().(*types.Signature)
-	if signature == nil {
-		return "{ name: " + strconv.Quote(method.Name()) + ", args: [], returns: [] }"
+	if signature != nil {
+		if signature.Params().Len() != 0 || signature.Results().Len() != 0 {
+			args = append(args, o.runtimeMethodParameters(signature.Params(), seen))
+		}
+		if signature.Results().Len() != 0 {
+			args = append(args, o.runtimeMethodParameters(signature.Results(), seen))
+		}
 	}
-	return "{ name: " + strconv.Quote(method.Name()) +
-		", args: " + o.runtimeMethodArgs(signature.Params(), seen) +
-		", returns: " + o.runtimeMethodReturns(signature.Results(), seen) + " }"
+	return helper + "(" + strings.Join(args, ", ") + ")"
 }
 
 func (o *LoweringOwner) runtimeTrimmedMethodSignature(method *types.Func, seen map[types.Type]bool) string {
@@ -3213,18 +3218,17 @@ func (o *LoweringOwner) runtimeMethodAssertSignature(ctx lowerFileContext, metho
 		", returns: " + o.runtimeMethodAssertReturns(ctx, signature.Results(), seen) + " }"
 }
 
-func (o *LoweringOwner) runtimeMethodArgs(tuple *types.Tuple, seen map[types.Type]bool) string {
+func (o *LoweringOwner) runtimeMethodParameters(tuple *types.Tuple, seen map[types.Type]bool) string {
 	if tuple == nil || tuple.Len() == 0 {
 		return "[]"
 	}
 	args := make([]string, 0, tuple.Len())
-	for idx := range tuple.Len() {
-		param := tuple.At(idx)
-		name := param.Name()
-		if name == "" {
-			name = "_p" + strconv.Itoa(idx)
+	for param := range tuple.Variables() {
+		value := o.runtimeTypeInfoExprWithSeen(param.Type(), seen)
+		if name := param.Name(); name != "" {
+			value = "[" + strconv.Quote(name) + ", " + value + "]"
 		}
-		args = append(args, "{ name: "+strconv.Quote(name)+", type: "+o.runtimeTypeInfoExprWithSeen(param.Type(), seen)+" }")
+		args = append(args, value)
 	}
 	return "[" + strings.Join(args, ", ") + "]"
 }
@@ -3256,22 +3260,6 @@ func (o *LoweringOwner) runtimeMethodAssertArgs(ctx lowerFileContext, tuple *typ
 		args = append(args, "{ name: "+strconv.Quote(name)+", type: "+o.runtimeTypeAssertInfoExprWithSeen(ctx, param.Type(), seen)+" }")
 	}
 	return "[" + strings.Join(args, ", ") + "]"
-}
-
-func (o *LoweringOwner) runtimeMethodReturns(tuple *types.Tuple, seen map[types.Type]bool) string {
-	if tuple == nil || tuple.Len() == 0 {
-		return "[]"
-	}
-	results := make([]string, 0, tuple.Len())
-	for idx := range tuple.Len() {
-		result := tuple.At(idx)
-		name := result.Name()
-		if name == "" {
-			name = "_r" + strconv.Itoa(idx)
-		}
-		results = append(results, "{ name: "+strconv.Quote(name)+", type: "+o.runtimeTypeInfoExprWithSeen(result.Type(), seen)+" }")
-	}
-	return "[" + strings.Join(results, ", ") + "]"
 }
 
 func (o *LoweringOwner) runtimeTrimmedMethodReturns(tuple *types.Tuple, seen map[types.Type]bool) string {

--- a/compiler/runtime-contract.go
+++ b/compiler/runtime-contract.go
@@ -135,6 +135,7 @@ const (
 	RuntimeHelperToGoError RuntimeHelper = "error.toGoError"
 
 	RuntimeHelperBasicType                RuntimeHelper = "type.basicType"
+	RuntimeHelperMethodSignature          RuntimeHelper = "type.methodSignature"
 	RuntimeHelperTypeKind                 RuntimeHelper = "type.TypeKind"
 	RuntimeHelperRegisterStructType       RuntimeHelper = "type.registerStructType"
 	RuntimeHelperRegisterInterfaceType    RuntimeHelper = "type.registerInterfaceType"
@@ -384,6 +385,7 @@ func runtimeHelperContracts() []RuntimeHelperContract {
 		runtimeHelper(RuntimeHelperNewError, "newError", RuntimeHelperCategoryError),
 		runtimeHelper(RuntimeHelperToGoError, "toGoError", RuntimeHelperCategoryError),
 		runtimeHelper(RuntimeHelperBasicType, "basicType", RuntimeHelperCategoryType),
+		runtimeHelper(RuntimeHelperMethodSignature, "methodSignature", RuntimeHelperCategoryType),
 		runtimeHelper(RuntimeHelperTypeKind, "TypeKind", RuntimeHelperCategoryType),
 		runtimeHelper(RuntimeHelperRegisterStructType, "registerStructType", RuntimeHelperCategoryType),
 		runtimeHelper(RuntimeHelperRegisterInterfaceType, "registerInterfaceType", RuntimeHelperCategoryType),

--- a/gs/builtin/type.test.ts
+++ b/gs/builtin/type.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   basicType,
+  methodSignature,
   registerStructType,
   type MethodSignature,
   type StructFieldInfo,
@@ -100,7 +101,14 @@ describe('deferred struct metadata', () => {
     let methodReads = 0
     let fieldReads = 0
     class Sample {}
-    const methods: MethodSignature[] = [{ name: 'Read', args: [], returns: [] }]
+    const methods: MethodSignature[] = [
+      methodSignature(
+        'Read',
+        [basicType('int'), ['offset', 'main.Offset']],
+        ['error', ['n', basicType('int')]],
+      ),
+      methodSignature('Close'),
+    ]
     const fields: StructFieldInfo[] = [
       { name: 'Value', type: basicType('int') },
     ]
@@ -120,6 +128,20 @@ describe('deferred struct metadata', () => {
     expect([methodReads, fieldReads]).toEqual([0, 0])
     expect(info.methods).toBe(methods)
     expect(info.methods).toBe(methods)
+    expect(info.methods).toEqual([
+      {
+        name: 'Read',
+        args: [
+          { name: '_p0', type: basicType('int') },
+          { name: 'offset', type: 'main.Offset' },
+        ],
+        returns: [
+          { name: '_r0', type: 'error' },
+          { name: 'n', type: basicType('int') },
+        ],
+      },
+      { name: 'Close', args: [], returns: [] },
+    ])
     expect([methodReads, fieldReads]).toEqual([1, 0])
     expect(info.fields).toBe(fields)
     expect(info.fields).toBe(fields)

--- a/gs/builtin/type.ts
+++ b/gs/builtin/type.ts
@@ -43,6 +43,36 @@ export interface MethodSignature {
   returns: MethodArg[]
 }
 
+/** MethodParameter encodes a type and an optional declared parameter name. */
+export type MethodParameter =
+  | TypeInfo
+  | string
+  | [name: string, type: TypeInfo | string]
+
+/** methodSignature expands generated parameter tables for runtime reflection. */
+export function methodSignature(
+  name: string,
+  args: readonly MethodParameter[] = [],
+  returns: readonly MethodParameter[] = [],
+): MethodSignature {
+  return {
+    name,
+    args: methodParameters(args, '_p'),
+    returns: methodParameters(returns, '_r'),
+  }
+}
+
+function methodParameters(
+  parameters: readonly MethodParameter[],
+  prefix: string,
+): MethodArg[] {
+  return parameters.map((parameter, index) =>
+    Array.isArray(parameter) ?
+      { name: parameter[0], type: parameter[1] }
+    : { name: prefix + index, type: parameter },
+  )
+}
+
 /**
  * StructFieldInfo Information about a struct field including type and optional tag.
  */

--- a/tests/tests/reflect_implements/reflect_implements.gs.ts
+++ b/tests/tests/reflect_implements/reflect_implements.gs.ts
@@ -13,7 +13,7 @@ export type Stringer = {
 $.registerInterfaceType(
 	"main.Stringer",
 	null,
-	[{ name: "String", args: [], returns: [{ name: "_r0", type: /* @__PURE__ */ $.basicType("string") }] }]
+	[$.methodSignature("String", [], [/* @__PURE__ */ $.basicType("string")])]
 );
 
 export class MyType {
@@ -40,7 +40,7 @@ export class MyType {
 	static __typeInfo = $.registerStructType(
 		"main.MyType",
 		() => new MyType(),
-		() => [{ name: "String", args: [], returns: [{ name: "_r0", type: /* @__PURE__ */ $.basicType("string") }] }],
+		() => [$.methodSignature("String", [], [/* @__PURE__ */ $.basicType("string")])],
 		MyType,
 		() => []
 	)

--- a/tests/tests/reflect_typefor/reflect_typefor.gs.ts
+++ b/tests/tests/reflect_typefor/reflect_typefor.gs.ts
@@ -19,7 +19,7 @@ export type MyInterface = {
 $.registerInterfaceType(
 	"main.MyInterface",
 	null,
-	[{ name: "SomeMethod", args: [], returns: [] }]
+	[$.methodSignature("SomeMethod")]
 );
 
 export class MyStruct {


### PR DESCRIPTION
Generated reflection metadata repeats argument and result object literals for every method. Emit compact parameter tables and expand them through one runtime helper, preserving declared names and lazy struct metadata.

Focused reflection compliance checks, runtime tests, and TypeScript checking pass. A fresh-browser application startup check passes; the complete core chunk set is 3.76 MB smaller after minification.
