### PR TITLE
perf(runtime): allocate variable pointer handles on demand

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -180,6 +180,8 @@ The runtime provides:
     *   Math: `$.int`, `$.byte`
 *   Runtime type information utilities (`$.registerStructType`, `$.registerInterfaceType`, `$.getTypeByName`, `$.TypeKind`). Basic descriptors use `$.basicType(name, typeName?)`; pointer, slice, array, map, and channel descriptors use corresponding runtime constructors. Each call returns a fresh descriptor; named identity and reflection contents remain unchanged. Method signatures use `$.methodSignature(name, args?, returns?)`, with each parameter encoded as a type or a `[name, type]` pair. Full field descriptors use `$.structField(name, type, index, offset, exported, options?)`, preserving storage keys, tags, visibility, and embedding metadata. Struct registration accepts field and method factories, evaluated independently on the first synchronous read and then retained. Registration still publishes the constructor and type name immediately; reflection observes the complete mutable arrays.
 
+Variable references retain distinct mutable cells. Pointer handles and their address/ref closures are allocated on the first pointer access and retained on that cell; ordinary field reads and writes do not allocate pointer machinery.
+
 Generated protobuf adapters declare their Go method types and install binary, JSON, clone, equality, and reset forwarding methods through the shared protobuf bridge. Installation occurs in the class static block, captures the declaring constructor for nil receiver calls, and preserves non-enumerable prototype methods. Handwritten methods and native proto-text bodies remain on their declaring classes.
 
 ## Known Divergences

--- a/gs/builtin/runtime-contract.test.ts
+++ b/gs/builtin/runtime-contract.test.ts
@@ -361,6 +361,10 @@ describe('builtin runtime contract helpers', () => {
     const localPointer = ownedPointerFromRef(local)
     expect(localPointer).toBeDefined()
     expect(ownedPointerRef(localPointer!)).toBe(local)
+    expect(ownedPointerFromRef(local)).toBe(localPointer)
+    expect(ownedPointerAddress(ownedPointerFromRef(varRef(1))!)).not.toBe(
+      ownedPointerAddress(localPointer!),
+    )
     expect(ownedPointerAddress(localPointer!)).toBe(local.__goAddress!())
     ownedPointerRef(localPointer!).value = 3
     expect(local.value).toBe(3)

--- a/gs/builtin/varRef.ts
+++ b/gs/builtin/varRef.ts
@@ -68,15 +68,25 @@ function refPointer<T>(
   }
 }
 
-/** varRef Wrap a non-null T in a variable reference. */
+/** VariableRef allocates pointer machinery only when its address is requested. */
+class VariableRef<T> implements VarRef<T> {
+  readonly __isVarRef = true
+  private pointer?: OwnedPointerHandle<T>
+
+  constructor(public value: T) {}
+
+  get __goPointer(): OwnedPointerHandle<T> {
+    return (this.pointer ??= refPointer(this, () => pointerAddress(this)))
+  }
+
+  get __goAddress(): () => number {
+    return this.__goPointer.__goAddress
+  }
+}
+
+/** varRef wraps a variable with distinct pointer identity. */
 export function varRef<T>(v: T): VarRef<T> {
-  // We create a new object wrapper for every varRef call to ensure
-  // distinct pointer identity, crucial for pointer comparisons (p1 == p2).
-  // The __isVarRef marker allows the reflect system to identify this as a pointer type.
-  const ref: VarRef<T> = { value: v, __isVarRef: true }
-  ref.__goAddress = () => pointerAddress(ref)
-  ref.__goPointer = refPointer(ref, ref.__goAddress)
-  return ref
+  return new VariableRef(v)
 }
 
 /** fieldRef Create a variable reference to an object field. */


### PR DESCRIPTION
Ordinary variable references eagerly allocate pointer handles and closures even when only their values are used. Allocate and retain that machinery on first pointer access while preserving distinct cells and stable pointer identity.

Runtime contract tests, TypeScript checking, and fresh-browser application startup checks pass. A Node allocation experiment retaining 100,000 references reduced immediate heap growth from about 32.8 MB to 5.6 MB.
