### PR TITLE
perf(compiler): reuse constructors for struct cloning

### DIFF
--- a/compiler/compiler-cache.go
+++ b/compiler/compiler-cache.go
@@ -27,7 +27,7 @@ const compilerCacheSchema = "goscript-package-artifact-v1"
 // compilerSemanticsVersion versions emitted-output semantics. Bump this value
 // with every behavior-changing compiler commit so artifacts cached by an
 // older binary miss and rebuild instead of replaying stale bytes.
-const compilerSemanticsVersion = "10"
+const compilerSemanticsVersion = "12"
 
 type compilerCacheEntryKind string
 

--- a/compiler/typescript-emitter.go
+++ b/compiler/typescript-emitter.go
@@ -514,43 +514,11 @@ func renderStruct(b *strings.Builder, structType *loweredStruct, runtimeOwner *R
 	b.WriteString(structType.cloneMethod)
 	b.WriteString("(): ")
 	b.WriteString(structType.name)
-	b.WriteString(" {\n\t\tconst cloned = new ")
-	b.WriteString(structType.name)
-	b.WriteString("()\n\t\tcloned._fields = {\n")
-	for idx, field := range structType.fields {
-		b.WriteString("\t\t\t")
-		b.WriteString(field.name)
-		b.WriteString(": ")
-		b.WriteString(varRef)
-		b.WriteString("(")
-		if field.structValue {
-			b.WriteString(markStructValue)
-			b.WriteString("(")
-			b.WriteString(cloneStructValue)
-			b.WriteString("(this._fields.")
-			b.WriteString(field.name)
-			b.WriteString(".value))")
-		} else if field.arrayValue {
-			b.WriteString(cloneArrayValue)
-			b.WriteString("(this._fields.")
-			b.WriteString(field.name)
-			b.WriteString(".value, ")
-			b.WriteString(field.runtimeType)
-			b.WriteString(")")
-		} else {
-			b.WriteString("this._fields.")
-			b.WriteString(field.name)
-			b.WriteString(".value")
-		}
-		b.WriteString(")")
-		if idx != len(structType.fields)-1 {
-			b.WriteString(",")
-		}
-		b.WriteString("\n")
-	}
-	b.WriteString("\t\t}\n\t\treturn ")
+	b.WriteString(" {\n\t\treturn ")
 	b.WriteString(markStructValue)
-	b.WriteString("(cloned)\n\t}\n")
+	b.WriteString("(new ")
+	b.WriteString(structType.name)
+	b.WriteString("(this))\n\t}\n")
 	for _, method := range structType.methods {
 		b.WriteString("\n")
 		renderMethod(b, &method)

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -180,6 +180,8 @@ The runtime provides:
     *   Math: `$.int`, `$.byte`
 *   Runtime type information utilities (`$.registerStructType`, `$.registerInterfaceType`, `$.getTypeByName`, `$.TypeKind`). Basic descriptors use `$.basicType(name, typeName?)`; pointer, slice, array, map, and channel descriptors use corresponding runtime constructors. Each call returns a fresh descriptor; named identity and reflection contents remain unchanged. Method signatures use `$.methodSignature(name, args?, returns?)`, with each parameter encoded as a type or a `[name, type]` pair. Full field descriptors use `$.structField(name, type, index, offset, exported, options?)`, preserving storage keys, tags, visibility, and embedding metadata. Struct registration accepts field and method factories, evaluated independently on the first synchronous read and then retained. Registration still publishes the constructor and type name immediately; reflection observes the complete mutable arrays.
 
+Generated clone methods pass the source instance to the declaring constructor, which owns field-copy rules. Cloning creates fresh field cells without a discarded zero-initialization pass or a duplicate field-copy loop.
+
 Generated classes declare their field types and install non-enumerable prototype accessors with `$.bindStructFields`. These accessors read and write the existing `_fields` cells; taking a field address and assigning through that address use the same cell.
 
 Variable references retain distinct mutable cells. Pointer handles and their address/ref closures are allocated on the first pointer access and retained on that cell; ordinary field reads and writes do not allocate pointer machinery.

--- a/tests/tests/blank_struct_fields/blank_struct_fields.gs.ts
+++ b/tests/tests/blank_struct_fields/blank_struct_fields.gs.ts
@@ -25,13 +25,7 @@ export class padded {
 	}
 
 	public clone(): padded {
-		const cloned = new padded()
-		cloned._fields = {
-			_blank0: $.varRef($.cloneArrayValue(this._fields._blank0.value, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 2))),
-			Value: $.varRef(this._fields.Value.value),
-			_blank2: $.varRef($.cloneArrayValue(this._fields._blank2.value, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 3)))
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new padded(this))
 	}
 
 	static {

--- a/tests/tests/generic_constrained_slice_clone/generic_constrained_slice_clone.gs.ts
+++ b/tests/tests/generic_constrained_slice_clone/generic_constrained_slice_clone.gs.ts
@@ -14,12 +14,7 @@ $.registerInterfaceType(
 );
 
 export class item {
-	public get value(): string {
-		return this._fields.value.value
-	}
-	public set value(value: string) {
-		this._fields.value.value = value
-	}
+	public declare value: string
 
 	public _fields: {
 		value: $.VarRef<string>
@@ -32,11 +27,7 @@ export class item {
 	}
 
 	public clone(): item {
-		const cloned = new item()
-		cloned._fields = {
-			value: $.varRef(this._fields.value.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new item(this))
 	}
 
 	public CloneVT(): item | $.VarRef<item> | null {
@@ -47,10 +38,14 @@ export class item {
 		return new item({value: $.pointerValue<item>(i).value})
 	}
 
+	static {
+		$.bindStructFields(this.prototype, ["value"])
+	}
+
 	static __typeInfo = $.registerStructType(
 		"main.item",
 		() => new item(),
-		() => [{ name: "CloneVT", args: [], returns: [{ type: { kind: $.TypeKind.Pointer, elemType: "main.item" } }] }],
+		() => [{ name: "CloneVT", args: [], returns: [{ type: /* @__PURE__ */ $.pointerType("main.item") }] }],
 		item,
 		() => [{ name: "value", key: "value", type: /* @__PURE__ */ $.basicType("string") }]
 	)
@@ -67,7 +62,7 @@ export async function cloneSlice<T>(__typeArgs: $.GenericTypeArgs | undefined, i
 
 export async function main(): globalThis.Promise<void> {
 	let items: $.Slice<item | $.VarRef<item> | null> = $.arrayToSlice<item | $.VarRef<item> | null>([new item({value: "first"}), new item({value: "second"})])
-	let cloned: $.Slice<item | $.VarRef<item> | null> = (await cloneSlice({[$.genericTypeArgsMarker]: $.genericTypeArgsBrand, T: { type: { kind: $.TypeKind.Pointer, elemType: "main.item" }, zero: () => null, methods: {CloneVT: (receiver: any, ...args: any[]) => $.pointerValue(receiver).CloneVT(...$.stripGenericTypeArgs(args))} }}, items) as $.Slice<item | $.VarRef<item> | null>)
+	let cloned: $.Slice<item | $.VarRef<item> | null> = (await cloneSlice({[$.genericTypeArgsMarker]: $.genericTypeArgsBrand, T: { type: /* @__PURE__ */ $.pointerType("main.item"), zero: () => null, methods: {CloneVT: (receiver: any, ...args: any[]) => $.pointerValue(receiver).CloneVT(...$.stripGenericTypeArgs(args))} }}, items) as $.Slice<item | $.VarRef<item> | null>)
 	await $.println($.len(cloned), $.pointerValue<item>($.arrayIndex(cloned!, 0)).value, $.pointerValue<item>($.arrayIndex(cloned!, 1)).value, $.pointerEqual($.arrayIndex(cloned!, 0), $.arrayIndex(items!, 0)))
 }
 

--- a/tests/tests/pointer_struct_assign_clone/pointer_struct_assign_clone.gs.ts
+++ b/tests/tests/pointer_struct_assign_clone/pointer_struct_assign_clone.gs.ts
@@ -17,11 +17,7 @@ export class MyStruct {
 	}
 
 	public clone(): MyStruct {
-		const cloned = new MyStruct()
-		cloned._fields = {
-			Value: $.varRef(this._fields.Value.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new MyStruct(this))
 	}
 
 	static {

--- a/tests/tests/struct_method_clone_collision/struct_method_clone_collision.gs.ts
+++ b/tests/tests/struct_method_clone_collision/struct_method_clone_collision.gs.ts
@@ -4,12 +4,7 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export class Box {
-	public get Value(): number {
-		return this._fields.Value.value
-	}
-	public set Value(value: number) {
-		this._fields.Value.value = value
-	}
+	public declare Value: number
 
 	public _fields: {
 		Value: $.VarRef<number>
@@ -22,11 +17,7 @@ export class Box {
 	}
 
 	public __goscriptClone(): Box {
-		const cloned = new Box()
-		cloned._fields = {
-			Value: $.varRef(this._fields.Value.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new Box(this))
 	}
 
 	public clone(): Box | $.VarRef<Box> | null {
@@ -34,10 +25,14 @@ export class Box {
 		return new Box({Value: $.pointerValue<Box>(b).Value + 1})
 	}
 
+	static {
+		$.bindStructFields(this.prototype, ["Value"])
+	}
+
 	static __typeInfo = $.registerStructType(
 		"main.Box",
 		() => new Box(),
-		() => [{ name: "clone", args: [], returns: [{ type: { kind: $.TypeKind.Pointer, elemType: "main.Box" } }] }],
+		() => [{ name: "clone", args: [], returns: [{ type: /* @__PURE__ */ $.pointerType("main.Box") }] }],
 		Box,
 		() => [{ name: "Value", key: "Value", type: /* @__PURE__ */ $.basicType("int") }]
 	)

--- a/tests/tests/struct_value_init_clone/struct_value_init_clone.gs.ts
+++ b/tests/tests/struct_value_init_clone/struct_value_init_clone.gs.ts
@@ -4,19 +4,9 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export class Point {
-	public get X(): number {
-		return this._fields.X.value
-	}
-	public set X(value: number) {
-		this._fields.X.value = value
-	}
+	public declare X: number
 
-	public get Y(): number {
-		return this._fields.Y.value
-	}
-	public set Y(value: number) {
-		this._fields.Y.value = value
-	}
+	public declare Y: number
 
 	public _fields: {
 		X: $.VarRef<number>
@@ -31,12 +21,11 @@ export class Point {
 	}
 
 	public clone(): Point {
-		const cloned = new Point()
-		cloned._fields = {
-			X: $.varRef(this._fields.X.value),
-			Y: $.varRef(this._fields.Y.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new Point(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["X", "Y"])
 	}
 
 	static __typeInfo = $.registerStructType(

--- a/tests/tests/varref_struct_init/varref_struct_init.gs.ts
+++ b/tests/tests/varref_struct_init/varref_struct_init.gs.ts
@@ -17,11 +17,7 @@ export class MyStruct {
 	}
 
 	public clone(): MyStruct {
-		const cloned = new MyStruct()
-		cloned._fields = {
-			MyInt: $.varRef(this._fields.MyInt.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new MyStruct(this))
 	}
 
 	static {


### PR DESCRIPTION
Generated clone methods reuse the declaring constructor's field-copy rules. This removes the duplicate copy loop and avoids allocating zero-valued cells only to discard them.

Existing value-copy, pointer-assignment, generic-clone, method-name-collision, initialization, and blank-field checks pass, along with a fresh-browser application startup check. The complete minified core chunk set is 1.13 MB smaller.
