### PR TITLE
perf(runtime): allocate field pointer handles on demand

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -184,7 +184,7 @@ Generated clone methods pass the source instance to the declaring constructor, w
 
 Generated classes declare their field types and install non-enumerable prototype accessors with `$.bindStructFields`. These accessors read and write values stored directly in `_fields`. Taking a field address uses `$.fieldRef` on that record and key. The runtime retains one stable reference per addressed field; ordinary construction allocates no field-reference cells. Struct assignment updates the existing target record, preserving held field pointers, and unsafe pointer views share the same record. Runtime overrides, reflection, codecs, equality, and printing use this representation together. The compiler semantic version invalidates previously generated output; no mixed representation is supported.
 
-Standalone variable references retain distinct mutable cells. Pointer handles and their address/ref closures are allocated on the first pointer access and retained on that cell; ordinary field reads and writes do not allocate pointer machinery.
+Standalone variable references retain distinct mutable cells. Variable and field references share their accessors through class prototypes. Pointer handles and their address/ref closures are allocated on the first pointer access and retained on that reference; ordinary field reads and writes do not allocate pointer machinery.
 
 Generated protobuf adapters declare their Go method types and install binary, JSON, clone, equality, and reset forwarding methods through the shared protobuf bridge. Installation occurs in the class static block, captures the declaring constructor for nil receiver calls, and preserves non-enumerable prototype methods. Handwritten methods and native proto-text bodies remain on their declaring classes.
 

--- a/gs/builtin/varRef.ts
+++ b/gs/builtin/varRef.ts
@@ -69,6 +69,35 @@ class VariableRef<T> implements VarRef<T> {
   }
 }
 
+/** FieldReference keeps field access separate from lazily requested pointers. */
+class FieldReference<T extends object, K extends keyof T> implements VarRef<
+  T[K]
+> {
+  readonly __isVarRef = true
+  private pointer?: OwnedPointerHandle<T[K]>
+
+  constructor(
+    private readonly target: T,
+    private readonly key: K,
+  ) {}
+
+  get value(): T[K] {
+    return this.target[this.key]
+  }
+
+  set value(value: T[K]) {
+    this.target[this.key] = value
+  }
+
+  get __goPointer(): OwnedPointerHandle<T[K]> {
+    return (this.pointer ??= refPointer(this, () => pointerAddress(this)))
+  }
+
+  get __goAddress(): () => number {
+    return this.__goPointer.__goAddress
+  }
+}
+
 /** varRef wraps a variable with distinct pointer identity. */
 export function varRef<T>(v: T): VarRef<T> {
   return new VariableRef(v)
@@ -104,18 +133,7 @@ export function fieldRef<T extends object, K extends keyof T>(
   }
   const existing = references.get(key)
   if (existing !== undefined) return existing as VarRef<T[K]>
-  const address = () => pointerAddress(ref)
-  const ref: VarRef<T[K]> = {
-    get value(): T[K] {
-      return target[key]
-    },
-    set value(value: T[K]) {
-      target[key] = value
-    },
-    __isVarRef: true,
-    __goAddress: address,
-  }
-  ref.__goPointer = refPointer(ref, address)
+  const ref = new FieldReference(target, key)
   references.set(key, ref)
   return ref
 }


### PR DESCRIPTION
Field references now share getter and setter methods through a class prototype and allocate their pointer handle only when requested, matching standalone variable references. Repeated references retain the same object and address identity.

Type checking, focused lint, runtime pointer checks, and the fresh Chromium Drive scenario pass. A retained-reference benchmark with 100,000 fields falls from 93,926,008 to 32,319,304 heap bytes. The browser run took 7.32 seconds from navigation, within the preceding untraced range of 6.82 to 7.39 seconds; no whole-startup speedup is claimed.
