### PR TITLE
perf(io): grow default copy buffers for bulk transfers

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -186,6 +186,8 @@ Generated classes declare their field types and install non-enumerable prototype
 
 Standalone variable references retain distinct mutable cells. Variable and field references share their accessors through class prototypes. Pointer handles and their address/ref closures are allocated on the first pointer access and retained on that reference; ordinary field reads and writes do not allocate pointer machinery.
 
+The `io.Copy` and `io.CopyN` fallback starts with a 32 KiB buffer and grows it after full reads to a 256 KiB ceiling. This bounds memory while reducing asynchronous reader/writer transitions for bulk transfers. `CopyBuffer` preserves a caller-supplied buffer, and `WriterTo` or `ReaderFrom` still owns copying when available.
+
 Generated protobuf adapters declare their Go method types and install binary, JSON, clone, equality, and reset forwarding methods through the shared protobuf bridge. Installation occurs in the class static block, captures the declaring constructor for nil receiver calls, and preserves non-enumerable prototype methods. Handwritten methods and native proto-text bodies remain on their declaring classes.
 
 ## Known Divergences

--- a/gs/io/io.test.ts
+++ b/gs/io/io.test.ts
@@ -207,17 +207,35 @@ describe('io override', () => {
     expect(Buffer.from(buf).toString('utf8')).toBe('later')
   })
 
-  test('Copy copies bytes until EOF and reports nil error', async () => {
-    const writer = new captureWriter()
+  test('Copy transfers large async inputs with bounded bulk reads', async () => {
+    const input = Uint8Array.from(
+      { length: 1024 * 1024 + 17 },
+      (_, i) => i % 251,
+    )
+    const output = new Uint8Array(input.length)
+    const reader = new sliceReader(input)
+    let offset = 0
 
     const [written, err] = await Copy(
-      writer,
-      new sliceReader($.stringToBytes('hello world')),
+      {
+        async Write(data: $.Bytes): Promise<[number, $.GoError]> {
+          output.set(data!, offset)
+          offset += $.len(data)
+          return [$.len(data), null]
+        },
+      },
+      {
+        async Read(data: $.Bytes): Promise<[number, $.GoError]> {
+          return reader.Read(data)
+        },
+      },
     )
 
     expect(err).toBeNull()
-    expect(written).toBe(11n)
-    expect(Buffer.from(writer.chunks).toString('utf8')).toBe('hello world')
+    expect(written).toBe(BigInt(input.length))
+    expect(output).toEqual(input)
+    expect(reader.requestedSizes.length).toBeLessThanOrEqual(10)
+    expect(Math.max(...reader.requestedSizes)).toBeLessThanOrEqual(256 * 1024)
   })
 
   test('CopyBuffer stages reads through the provided buffer', async () => {

--- a/gs/io/io.ts
+++ b/gs/io/io.ts
@@ -508,7 +508,7 @@ export async function Copy(
 }
 
 // CopyBuffer stages copying through buf unless a reader or writer owns the copy.
-// A nil buffer allocates a bounded 32 KiB buffer.
+// A nil buffer grows from 32 KiB to 256 KiB when full reads sustain bulk copying.
 export async function CopyBuffer(
   dst: WriterLike,
   src: ReaderLike,
@@ -529,6 +529,7 @@ export async function CopyBuffer(
     return await ((dst as ReaderFrom).ReadFrom(src) as any)
   }
 
+  const growBuffer = buf === null
   if (buf === null) {
     buf = $.makeSlice<number>(32 * 1024, undefined, 'byte')
   }
@@ -557,6 +558,9 @@ export async function CopyBuffer(
         break
       }
       return [written, er]
+    }
+    if (growBuffer && nr === $.len(buf) && $.len(buf) < 256 * 1024) {
+      buf = $.makeSlice<number>($.len(buf) * 2, undefined, 'byte')
     }
   }
   return [written, null]


### PR DESCRIPTION
The default CopyBuffer path grows from 32 KiB to a 256 KiB ceiling after full reads, reducing asynchronous reader/writer transitions during bulk transfers. Caller-supplied buffers and WriterTo/ReaderFrom precedence remain unchanged.

Type checking, focused lint, and 73 I/O and HTTP checks pass, including a bulk async copy using the existing scenario. The traced Chromium Drive run passes at 6.33 seconds from navigation. File-read calls fell from 1,550 to 286 in the retained comparison; combined file-read intervals fell from 1.15 to 0.95 seconds. Background work varied, so the whole-run timing is not a causal latency estimate.
