### PR TITLE
fix(runtime): preserve struct field identity and Go formatting

### DIFF
--- a/compiler/compiler-cache.go
+++ b/compiler/compiler-cache.go
@@ -27,7 +27,7 @@ const compilerCacheSchema = "goscript-package-artifact-v1"
 // compilerSemanticsVersion versions emitted-output semantics. Bump this value
 // with every behavior-changing compiler commit so artifacts cached by an
 // older binary miss and rebuild instead of replaying stale bytes.
-const compilerSemanticsVersion = "13"
+const compilerSemanticsVersion = "14"
 
 type compilerCacheEntryKind string
 

--- a/compiler/lowering.go
+++ b/compiler/lowering.go
@@ -1559,8 +1559,11 @@ func (o *LoweringOwner) lowerGenDecl(ctx lowerFileContext, decl *ast.GenDecl) ([
 						}
 					}
 					setterValue := "__goscriptValue"
-					setterCode := "export function " + setterName + "(" + setterValue + ": " + setterType + "): void {\n\t" +
-						setterTarget + " = " + setterValue + "\n}"
+					assignment := setterTarget + " = " + setterValue
+					if isStructValueType(obj.Type()) {
+						assignment = o.lowerStructAssignment(setterTarget, setterValue)
+					}
+					setterCode := "export function " + setterName + "(" + setterValue + ": " + setterType + "): void {\n\t" + assignment + "\n}"
 					setterIndexExport := ""
 					if ast.IsExported(name.Name) {
 						setterIndexExport = setterName
@@ -5228,10 +5231,8 @@ func (o *LoweringOwner) lowerAssignStmt(ctx lowerFileContext, stmt *ast.AssignSt
 		left, leftDiagnostics := o.lowerAssignmentTarget(ctx, lhs, isShortDecl)
 		diagnostics = append(diagnostics, leftDiagnostics...)
 		star, starTarget := unwrapParenExpr(lhs).(*ast.StarExpr)
-		if starTarget && stmt.Tok == token.ASSIGN && isStructValueType(targetType) {
-			pointer, pointerDiagnostics := o.lowerPointerValueExpr(ctx, star.X)
-			diagnostics = append(diagnostics, pointerDiagnostics...)
-			stmts = append(stmts, loweredStmt{text: o.runtimeOwner.QualifiedHelper(RuntimeHelperAssignStruct) + "(" + pointer + ", " + right + ")"})
+		if !isShortDecl && isStructValueType(targetType) {
+			stmts = append(stmts, loweredStmt{text: o.lowerStructAssignment(left, right)})
 			continue
 		}
 		if starTarget && stmt.Tok == token.ASSIGN {
@@ -5467,21 +5468,8 @@ func (o *LoweringOwner) lowerChannelReceiveAssignStmt(
 			return []loweredStmt{{text: "await " + o.runtimeOwner.QualifiedHelper(RuntimeHelperChanRecv) + "(" + channel + ")"}}, diagnostics
 		}
 		value := "await " + o.runtimeOwner.QualifiedHelper(RuntimeHelperChanRecv) + "(" + channel + ")"
-		if stmt.Tok != token.DEFINE {
-			if targetStmt, targetDiagnostics, ok := o.lowerStarTargetAssignmentStmt(ctx, stmt.Lhs[0], value); ok {
-				diagnostics = append(diagnostics, targetDiagnostics...)
-				return []loweredStmt{targetStmt}, diagnostics
-			}
-		}
-		left, leftDiagnostics := o.lowerAssignmentTarget(ctx, stmt.Lhs[0], stmt.Tok == token.DEFINE)
-		diagnostics = append(diagnostics, leftDiagnostics...)
-		prefix := ""
-		if stmt.Tok == token.DEFINE {
-			prefix = declarationKeyword(ctx)
-			left += o.shortDeclTypeAnnotation(ctx, stmt.Lhs[0], nil)
-			value = o.lowerDeclaredValue(ctx, stmt.Lhs[0], value)
-		}
-		return []loweredStmt{{text: prefix + left + " = " + value}}, diagnostics
+		targetStmt, targetDiagnostics := o.lowerTupleTargetAssignmentStmt(ctx, stmt.Lhs[0], value, stmt.Tok == token.DEFINE)
+		return []loweredStmt{targetStmt}, append(diagnostics, targetDiagnostics...)
 	}
 	tempName := ctx.tempName("Recv")
 	stmts := []loweredStmt{{text: "let " + tempName + " = await " + o.runtimeOwner.QualifiedHelper(RuntimeHelperChanRecvWithOk) + "(" + channel + ")"}}
@@ -5581,6 +5569,9 @@ func (o *LoweringOwner) lowerTupleTargetAssignmentStmt(
 		}
 	}
 	left, diagnostics := o.lowerAssignmentTarget(ctx, lhs, declare)
+	if !declare && isStructValueType(assignmentTargetType(ctx, lhs)) {
+		return loweredStmt{text: o.lowerStructAssignment(left, value)}, diagnostics
+	}
 	prefix := ""
 	if declare {
 		prefix = declarationKeyword(ctx)
@@ -5599,13 +5590,17 @@ func (o *LoweringOwner) lowerStarTargetAssignmentStmt(
 	if !ok {
 		return loweredStmt{}, nil, false
 	}
-	targetType := ctx.semPkg.source.TypesInfo.TypeOf(lhs)
-	if isStructValueType(targetType) {
+	if isStructValueType(ctx.semPkg.source.TypesInfo.TypeOf(lhs)) {
 		pointer, diagnostics := o.lowerPointerValueExpr(ctx, star.X)
-		return loweredStmt{text: o.runtimeOwner.QualifiedHelper(RuntimeHelperAssignStruct) + "(" + pointer + ", " + right + ")"}, diagnostics, true
+		return loweredStmt{text: o.lowerStructAssignment(pointer, right)}, diagnostics, true
 	}
 	pointer, diagnostics := o.lowerPointerStorageExpr(ctx, star.X)
 	return loweredStmt{text: pointer + " = " + right}, diagnostics, true
+}
+
+// lowerStructAssignment preserves the addresses of an existing struct's fields.
+func (o *LoweringOwner) lowerStructAssignment(target, value string) string {
+	return o.runtimeOwner.QualifiedHelper(RuntimeHelperAssignStruct) + "(" + target + ", " + value + ")"
 }
 
 func (o *LoweringOwner) lowerTupleReassignmentStmt(

--- a/compiler/skeleton_test.go
+++ b/compiler/skeleton_test.go
@@ -1915,7 +1915,8 @@ func TestCompilePackagesEmitsStructMethodsAndPointerAssertions(t *testing.T) {
 	text := string(content)
 	for _, want := range []string{
 		"export class Counter",
-		"// Value counts reads.\n\tpublic get Value(): number",
+		"// Value counts reads.\n\tpublic declare Value: number",
+		"$.bindStructFields(this.prototype, [\"Value\", \"ID\"])",
 		"public clone(): Counter",
 		"public Read(): number",
 		"public Set(v: number): void",
@@ -1925,7 +1926,7 @@ func TestCompilePackagesEmitsStructMethodsAndPointerAssertions(t *testing.T) {
 		"let pointer: Counter | $.VarRef<Counter> | null = original",
 		"Counter.prototype.Set.call(pointer, 2)",
 		"Counter.prototype.Set.call(NewCounter(), 5)",
-		"let [, ok] = $.typeAssertTuple<Counter | $.VarRef<Counter> | null>(iface, { kind: $.TypeKind.Pointer, elemType: \"main.Counter\" })",
+		"let [, ok] = $.typeAssertTuple<Counter | $.VarRef<Counter> | null>(iface, /* @__PURE__ */ $.pointerType(\"main.Counter\"))",
 		"{ name: \"Value\", key: \"Value\", type: /* @__PURE__ */ $.basicType(\"int\"), tag: \"json:\\\"value\\\"\" }",
 		"{ name: \"ID\", key: \"ID\", type: /* @__PURE__ */ $.basicType(\"int32\", \"main.ObjectID\") }",
 	} {
@@ -2328,8 +2329,8 @@ func TestCompilePackagesClonesNestedStructFieldsWithCloneMethodCollision(t *test
 	text := string(content)
 	for _, want := range []string{
 		"public __goscriptClone(): Box",
-		"Box: $.varRef(init?.Box ? $.markAsStructValue($.cloneStructValue(init.Box)) : $.markAsStructValue(new Box()))",
-		"Box: $.varRef($.markAsStructValue($.cloneStructValue(this._fields.Box.value)))",
+		"Box: init?.Box ? $.markAsStructValue($.cloneStructValue(init.Box)) : $.markAsStructValue(new Box())",
+		"return $.markAsStructValue(new Holder(this))",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing %q in generated output:\n%s", want, text)

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -154,7 +154,7 @@ Methods with both receiver and method type parameters remain unsupported: the de
 
 ### Variable References and Pointers
 
-See `design/VAR_REFS.md`. Go pointers are represented using a `$.VarRef<T>` wrapper type provided by the runtime. This allows emulating pointer semantics (shared reference, ability to modify the original value indirectly) in TypeScript.
+See `design/VAR_REFS.md` for the original storage-identity requirement and [VAR_REFS_CURRENT.md](VAR_REFS_CURRENT.md) for the current representation and checks. Go pointers use variable references or direct named-struct instances, with `pointerValue` handling both struct-pointer representations.
 
 *   Taking the address (`&x`): Often implicit when assigning to a variable expecting a `$.VarRef<T>`, or explicitly `$.varRef(x)`.
 *   Dereferencing (`*p`): Accessing the `p.value` property.
@@ -181,6 +181,8 @@ The runtime provides:
 *   Runtime type information utilities (`$.registerStructType`, `$.registerInterfaceType`, `$.getTypeByName`, `$.TypeKind`). Basic descriptors use `$.basicType(name, typeName?)`; pointer, slice, array, map, and channel descriptors use corresponding runtime constructors. Each call returns a fresh descriptor; named identity and reflection contents remain unchanged. Method signatures use `$.methodSignature(name, args?, returns?)`, with each parameter encoded as a type or a `[name, type]` pair. Full field descriptors use `$.structField(name, type, index, offset, exported, options?)`, preserving storage keys, tags, visibility, and embedding metadata. Struct registration accepts field and method factories, evaluated independently on the first synchronous read and then retained. Registration still publishes the constructor and type name immediately; reflection observes the complete mutable arrays.
 
 Generated clone methods pass the source instance to the declaring constructor, which owns field-copy rules. Cloning creates a fresh field record without a discarded zero-initialization pass or a duplicate field-copy loop.
+
+Assignments to existing named structs use `assignStruct` to preserve their storage, including nested struct and array fields. Reflection uses the same operation and the same canonical field references as generated address expressions. `fmt` renders Go fields and pointer addresses rather than enumerating JavaScript storage properties.
 
 Generated classes declare their field types and install non-enumerable prototype accessors with `$.bindStructFields`. These accessors read and write values stored directly in `_fields`. Taking a field address uses `$.fieldRef` on that record and key. The runtime retains one stable reference per addressed field; ordinary construction allocates no field-reference cells. Struct assignment updates the existing target record, preserving held field pointers, and unsafe pointer views share the same record. Runtime overrides, reflection, codecs, equality, and printing use this representation together. The compiler semantic version invalidates previously generated output; no mixed representation is supported.
 
@@ -616,8 +618,8 @@ After reviewing the code and tests, some important implementation considerations
 
 Go's value semantics (where assigning a struct copies it) are emulated in TypeScript by:
 1.  Adding a `clone()` method to generated classes representing structs. This method performs a deep copy.
-    -   The `clone()` method creates a new instance of the struct and then copies the values from the original struct's `_fields` to the new instance's `_fields`. For each field, the value is retrieved from the source variable reference (e.g., `this._fields.MyInt.value`) and then re-wrapped in a new variable reference in the destination (e.g., `cloned._fields.MyInt = $.varRef(...)`).
-    -   For nested struct fields, the `clone()` method of the nested struct is called recursively (e.g., `cloned._fields.InnerStruct = $.varRef(this._fields.InnerStruct.value?.clone() ?? new MyStruct())`).
+    -   The `clone()` method creates a new instance through the declaring constructor, passing `this` as its initializer. Fields are values in `_fields`, and constructor reads use the shared prototype accessors.
+    -   The constructor copies nested struct fields through `cloneStructValue` and array fields through `cloneArrayValue`. Pointer and other reference-valued fields retain their references.
     ```typescript
     // Example: MyStruct.clone()
     public clone(): MyStruct {

--- a/design/VAR_REFS_CURRENT.md
+++ b/design/VAR_REFS_CURRENT.md
@@ -1,0 +1,17 @@
+# Current variable and field references
+
+The handwritten [VarRef design](VAR_REFS.md) records the original requirement: an address identifies a variable's storage, and every pointer to that storage observes its current value. Its representation examples are historical. This note describes the current compiler and runtime.
+
+`varRef(value)` creates a variable cell when analysis determines that the variable needs an address. A pointer variable needs its own cell only when its address is taken. A pointer to a named struct can be a direct class instance or a `VarRef` containing that instance; generated dereferences use `pointerValue` for both representations.
+
+Generated structs store their values directly in `_fields`. Prototype accessors expose ordinary field reads and writes. `fieldRef(record, key)` returns the same reference for every address of that field. The reference reads and writes the record; constructing an unaddressed field allocates no reference cell. A pointer-valued field stores its pointer directly, so taking that field's address adds a reference around the pointer rather than dereferencing it.
+
+Variable and field references allocate their owned pointer handle when `__goPointer` or `__goAddress` is first requested. These properties are prototype accessors. Pointer consumers use the reference API directly, rather than copying its JavaScript properties.
+
+Cloning creates independent value storage through the declaring constructor. Assignment to an existing named struct uses `assignStruct`, preserving the target's field record and recursively preserving nested struct and array storage. Pointer, slice, map, and interface fields receive the source references. The compiler prepares the source value before assigning it. Ordinary, pointer, tuple, channel-receive, and package-variable assignments share this rule. Reflection uses the same assignment helper and obtains field addresses from the same field record as generated code.
+
+For example, `p := &s.Count; s = Item{Count: 2}; *p = 3` leaves `s.Count == 3`, and `p == &s.Count` remains true. Replacing the struct instance or a nested aggregate would break that invariant even if the variable's outer `VarRef` remained intact.
+
+`fmt` uses Go field names, field order, and type metadata. `%v` prints struct values, `%+v` includes field names, and `%#v` includes struct type names. A top-level struct pointer prints `&` followed by its value. Nested pointers and scalar pointers print addresses, which also prevents recursive pointer graphs from expanding indefinitely. Runtime addresses are stable within a process, but their numeric values need not match another process. Builtin `print` and `println` retain their deterministic inspection format and omit reference machinery.
+
+The `varref_struct` compliance fixture checks held field pointers, nested aggregates, pointer fields, tuple and parallel assignment, package variables, and reflection against native Go. `fmt_struct_values` compares named and anonymous structs, pointer graphs, and a Logrus controller warning with native Go. Existing runtime tests exercise codecs, equality, reflection, and owned pointer handles. These checks establish the covered behaviors, not complete Go language or `fmt` conformance.

--- a/gs/builtin/builtin.ts
+++ b/gs/builtin/builtin.ts
@@ -1,7 +1,10 @@
 import type { Slice, SliceProxy, StringHeaderData } from './slice.js'
 import {
+  getTypeByName,
   isTypeInfoComparable,
   pointerIdentityEqual,
+  structFieldRuntimeKey,
+  TypeKind,
   type TypeInfo,
 } from './type.js'
 import { writeHostStdoutText } from './hostio.js'
@@ -72,11 +75,15 @@ function clearZeroValue<T>(v: T[]): T {
 }
 
 /**
- * assignStruct copies all field values from source struct to target struct.
- * Used for pointer dereference assignment: *p = value
- * Copies the _fields contents from source to target.
+ * assignStruct copies a prepared struct value into existing storage. Nested
+ * structs and arrays retain their addresses; pointer and slice fields receive
+ * the source references. The compiler snapshots the right-hand side first.
  */
-export function assignStruct<T>(target: T, source: T): void {
+export function assignStruct<T>(
+  target: T,
+  source: T,
+  typeInfo?: TypeInfo | string,
+): void {
   if (
     target === null ||
     target === undefined ||
@@ -87,6 +94,21 @@ export function assignStruct<T>(target: T, source: T): void {
   }
   const targetFields = (target as any)._fields
   const sourceFields = (source as any)._fields
+  const info = typeInfo ?? (source as any).constructor?.__typeInfo
+  const resolved = typeof info === 'string' ? getTypeByName(info) : info
+  if (resolved?.kind === TypeKind.Struct) {
+    const destination = targetFields ?? target
+    const values = sourceFields ?? source
+    for (const field of resolved.fields) {
+      const key = structFieldRuntimeKey(field)
+      destination[key] = assignFieldValue(
+        destination[key],
+        values[key],
+        field.type,
+      )
+    }
+    return
+  }
   if (!targetFields || !sourceFields) {
     // Structs without a _fields map (e.g. bound protobuf messages) carry their
     // data as plain enumerable properties. Copy a clone when the value defines
@@ -103,6 +125,26 @@ export function assignStruct<T>(target: T, source: T): void {
   for (const key of Object.keys(sourceFields)) {
     targetFields[key] = sourceFields[key]
   }
+}
+
+/** assignFieldValue preserves aggregate storage while replacing reference values. */
+function assignFieldValue(
+  target: any,
+  source: any,
+  typeInfo?: TypeInfo | string,
+): any {
+  const info = typeof typeInfo === 'string' ? getTypeByName(typeInfo) : typeInfo
+  if (info?.kind === TypeKind.Struct) {
+    assignStruct(target, source, info)
+    return target
+  }
+  if (info?.kind === TypeKind.Array) {
+    for (let i = 0; i < info.length; i++) {
+      target[i] = assignFieldValue(target[i], source[i], info.elemType)
+    }
+    return target
+  }
+  return source
 }
 
 /**

--- a/gs/builtin/print.test.ts
+++ b/gs/builtin/print.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { formatPrintedArgs } from './print.js'
+import { fieldRef, varRef } from './varRef.js'
 
 describe('builtin println formatting', () => {
   it('formats Uint8Array values with a stable inspect-style representation', () => {
@@ -44,5 +45,17 @@ describe('builtin println formatting', () => {
   Name: "hello",
   Count: 3,
 }`)
+  })
+
+  it('formats variable and field pointers without exposing pointer machinery', () => {
+    const storage = { Count: 3 }
+    const local = varRef(4)
+    const field = fieldRef(storage, 'Count')
+    const value = { _fields: { Local: local, Field: field } }
+    const expected = '{\n  Local: 4,\n  Field: 3,\n}'
+    expect(formatPrintedArgs([value])).toBe(expected)
+    void local.__goPointer
+    void field.__goPointer
+    expect(formatPrintedArgs([value])).toBe(expected)
   })
 })

--- a/gs/builtin/print.ts
+++ b/gs/builtin/print.ts
@@ -1,4 +1,5 @@
 import { asArray, isSliceProxy, type Slice } from './slice.js'
+import { isVarRef } from './varRef.js'
 
 // A transpiled Go Error(), String(), or GoString() method may be async, so
 // printed operands render through the MaybePromise convention: text when the
@@ -112,6 +113,10 @@ function formatValue(
   seen.add(value)
 
   try {
+    if (isVarRef(value)) {
+      return formatValue(value.value, depth, nested, seen)
+    }
+
     if (value instanceof Map) {
       return formatArray(
         Array.from(value.entries()).map(([k, v]) =>

--- a/gs/builtin/varRef.ts
+++ b/gs/builtin/varRef.ts
@@ -53,7 +53,7 @@ function refPointer<T>(
   }
 }
 
-/** VariableRef allocates pointer machinery only when its address is requested. */
+/** VariableRef allocates pointer machinery only when its pointer or address is requested. */
 class VariableRef<T> implements VarRef<T> {
   readonly __isVarRef = true
   private pointer?: OwnedPointerHandle<T>
@@ -117,6 +117,7 @@ export function bindStructFields(
         this._fields[name] = value
       },
       configurable: true,
+      enumerable: false,
     })
   }
 }

--- a/gs/fmt/fmt.test.ts
+++ b/gs/fmt/fmt.test.ts
@@ -126,9 +126,16 @@ describe('fmt basic value formatting', () => {
     expect(await fmt.Sprintf('%q', 0x110000)).toBe(JSON.stringify('�'))
   })
 
-  it('%p pointer-ish formatting fallback', async () => {
-    expect(await fmt.Sprintf('%p', {})).toBe('0x0')
-    expect(await fmt.Sprintf('%p', { __address: 255 })).toBe('0xff')
+  it('uses the same address for %p and scalar pointers nested in structs', async () => {
+    const storage = { count: 7 }
+    const pointer = $.fieldRef(storage, 'count')
+    const address = '0x' + pointer.__goAddress!().toString(16)
+    expect(await fmt.Sprintf('%p', pointer)).toBe(address)
+    expect(await fmt.Sprintf('%v', pointer)).toBe(address)
+    expect(await fmt.Sprintf('%+v', { Count: pointer })).toBe(
+      '{Count:' + address + '}',
+    )
+    expect(await fmt.Sprintf('%p', $.fieldRef(storage, 'count'))).toBe(address)
   })
 
   it('%v default formats for arrays/maps/sets', async () => {
@@ -338,7 +345,9 @@ describe('fmt spacing rules', () => {
 
 describe('fmt parseFormat basic cases', () => {
   it('Printf with %d, %s, %f, width and precision', async () => {
-    expect(await fmt.Sprintf('n=%d s=%s f=%f', 42, 'ok', 3.5)).toBe('n=42 s=ok f=3.5')
+    expect(await fmt.Sprintf('n=%d s=%s f=%f', 42, 'ok', 3.5)).toBe(
+      'n=42 s=ok f=3.5',
+    )
     expect(await fmt.Sprintf("'%5s'", 'hi')).toBe("'   hi'")
     expect(await fmt.Sprintf("'%-.3f'", 3.14159)).toBe("'3.142'") // JS rounds
     expect(await fmt.Sprintf("'%6.2f'", 3.14159)).toBe("'  3.14'")
@@ -352,7 +361,9 @@ describe('fmt parseFormat basic cases', () => {
   })
 
   it('Printf hex/octal/bin', async () => {
-    expect(await fmt.Sprintf('%x %X %o %b', 255, 255, 8, 5)).toBe('ff FF 10 101')
+    expect(await fmt.Sprintf('%x %X %o %b', 255, 255, 8, 5)).toBe(
+      'ff FF 10 101',
+    )
   })
 
   it('Printf %c for code points', async () => {

--- a/gs/fmt/fmt.ts
+++ b/gs/fmt/fmt.ts
@@ -3,6 +3,14 @@
 
 import * as $ from '@goscript/builtin/index.js'
 import { writeHostStdoutText } from '@goscript/builtin/hostio.js'
+import {
+  Array as ArrayKind,
+  PointerTo,
+  Slice as SliceKind,
+  Struct,
+  TypeOf,
+  Value,
+} from '@goscript/reflect/type.js'
 
 // Stringer Basic interfaces.
 export interface Stringer {
@@ -120,10 +128,7 @@ function formatValue(value: any, verb: string, flags = ''): string {
       }
       return JSON.stringify(String(value))
     case 'p': {
-      // pointer (address)
-      const addr = (value as any)?.__address
-      if (typeof addr === 'number') return '0x' + addr.toString(16)
-      return '0x0'
+      return formatPointer(value)
     }
     default:
       return String(value)
@@ -179,43 +184,152 @@ function joinMaybe(
   return `${prefix}${(parts as string[]).join(separator)}${suffix}`
 }
 
-function defaultFormatMaybe(value: any): MaybeString {
+/** formatPointer renders a stable runtime address without inspecting the pointee. */
+function formatPointer(value: any): string {
+  const pointer = new Value(value, PointerTo(TypeOf(value)))
+  return '0x' + pointer.Pointer().toString(16)
+}
+
+/** defaultFormatMaybe renders Go values without exposing their runtime storage. */
+function defaultFormatMaybe(
+  value: any,
+  flags = '',
+  depth = 0,
+  typeInfo?: $.TypeInfo | string,
+  allowMethods = true,
+): MaybeString {
   if (value === null || value === undefined) return '<nil>'
+  if ($.isTypedNilValue(value)) return '<nil>'
   if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string')
+    return flags.includes('#') ? JSON.stringify(value) : value
   if (typeof value === 'number' || typeof value === 'bigint') {
     return value.toString()
   }
   if (Array.isArray(value))
-    return joinMaybe(value.map(defaultFormatMaybe), ' ', '[', ']')
+    return joinMaybe(
+      value.map((item) => defaultFormatMaybe(item, flags, depth + 1)),
+      ' ',
+      '[',
+      ']',
+    )
   if (typeof value === 'object') {
-    // GoStringer is intentionally not consulted here: Go calls GoString only
-    // for the %#v verb, which formatValue handles before reaching this default
-    // path. %v, %s, Sprint, and Print use Error then Stringer.
-    // Prefer error interface if present
-    if ((value as any).Error && typeof (value as any).Error === 'function') {
+    // Go consults methods on exported fields, with GoString reserved for %#v.
+    const methodValue = $.isVarRef(value) ? value.value : value
+    if (allowMethods && flags.includes('#') && hasGoString(methodValue)) {
+      return toMaybeString(methodValue.GoString())
+    }
+    if (
+      allowMethods &&
+      !flags.includes('#') &&
+      typeof methodValue?.Error === 'function'
+    ) {
       try {
-        return toMaybeString((value as any).Error())
+        return toMaybeString(methodValue.Error())
       } catch {
         // Ignore error by continuing to next case.
       }
     }
-    // Check for Stringer interface
-    if ((value as any).String && typeof (value as any).String === 'function') {
+    if (
+      allowMethods &&
+      !flags.includes('#') &&
+      typeof methodValue?.String === 'function'
+    ) {
       try {
-        return toMaybeString((value as any).String())
+        return toMaybeString(methodValue.String())
       } catch {
         // Ignore error by continuing to next case.
       }
+    }
+    const declared =
+      typeof typeInfo === 'string' ? $.getTypeByName(typeInfo) : typeInfo
+    const descriptor =
+      (declared?.kind === $.TypeKind.Interface ? undefined : declared) ??
+      value.__goTypeInfo ??
+      value.constructor?.__typeInfo
+    const info =
+      typeof descriptor === 'string' ? $.getTypeByName(descriptor) : descriptor
+    if ($.isVarRef(value) || info?.kind === $.TypeKind.Pointer) {
+      const pointee =
+        $.isVarRef(value) ? value.value : (value.__goValue ?? value)
+      const elementDescriptor =
+        info?.kind === $.TypeKind.Pointer ? info.elemType : undefined
+      const element =
+        typeof elementDescriptor === 'string' ?
+          $.getTypeByName(elementDescriptor)
+        : elementDescriptor
+      if (
+        depth === 0 &&
+        pointee !== null &&
+        typeof pointee === 'object' &&
+        (element?.kind === $.TypeKind.Struct ||
+          element?.kind === $.TypeKind.Array ||
+          element?.kind === $.TypeKind.Slice ||
+          (element === undefined &&
+            [Struct, ArrayKind, SliceKind].includes(TypeOf(pointee).Kind())))
+      ) {
+        return joinMaybe(
+          [
+            defaultFormatMaybe(
+              pointee,
+              flags,
+              depth + 1,
+              element ?? pointee.constructor?.__typeInfo,
+              allowMethods,
+            ),
+          ],
+          '',
+          '&',
+        )
+      }
+      return formatPointer(value)
     }
     if ('__goValue' in value) {
-      return defaultFormatMaybe((value as { __goValue: unknown }).__goValue)
+      return defaultFormatMaybe(
+        value.__goValue,
+        flags,
+        depth,
+        typeInfo,
+        allowMethods,
+      )
+    }
+    if (
+      info?.kind === $.TypeKind.Struct ||
+      (value._fields &&
+        typeof value._fields === 'object' &&
+        !Array.isArray(value._fields)) ||
+      value.constructor === Object
+    ) {
+      const fields: $.StructFieldInfo[] =
+        info?.kind === $.TypeKind.Struct ?
+          info.fields
+        : Object.keys(value._fields ?? value).map((name) => ({
+            name,
+            key: name,
+            type: $.basicType('unknown'),
+          }))
+      const storage = value._fields ?? value
+      const parts = fields.map((field) => {
+        const formatted = defaultFormatMaybe(
+          storage[$.structFieldRuntimeKey(field)],
+          flags,
+          depth + 1,
+          field.type,
+          allowMethods && (field.exported ?? /^\p{Lu}/u.test(field.name)),
+        )
+        const prefix =
+          flags.includes('+') || flags.includes('#') ? field.name + ':' : ''
+        return joinMaybe([formatted], '', prefix)
+      })
+      const name = flags.includes('#') ? (info?.name ?? '') : ''
+      return joinMaybe(parts, flags.includes('#') ? ', ' : ' ', name + '{', '}')
     }
     // Basic Map/Set rendering
     if (value instanceof Map) {
       const parts: MaybeString[] = []
       for (const [k, v] of (value as Map<any, any>).entries()) {
-        const key = defaultFormatMaybe(k)
-        const elem = defaultFormatMaybe(v)
+        const key = defaultFormatMaybe(k, flags, depth + 1)
+        const elem = defaultFormatMaybe(v, flags, depth + 1)
         if (isPromiseLike(key) || isPromiseLike(elem)) {
           parts.push(
             Promise.all([Promise.resolve(key), Promise.resolve(elem)]).then(
@@ -231,7 +345,7 @@ function defaultFormatMaybe(value: any): MaybeString {
     if (value instanceof Set) {
       const parts: MaybeString[] = []
       for (const v of (value as Set<any>).values()) {
-        parts.push(defaultFormatMaybe(v))
+        parts.push(defaultFormatMaybe(v, flags, depth + 1))
       }
       return joinMaybe(parts, ' ', '[', ']')
     }
@@ -242,7 +356,7 @@ function defaultFormatMaybe(value: any): MaybeString {
     ) {
       const parts = Object.entries(value as Record<string, any>).map(
         ([k, v]) => {
-          const formatted = defaultFormatMaybe(v)
+          const formatted = defaultFormatMaybe(v, flags, depth + 1)
           if (isPromiseLike(formatted)) {
             return formatted.then((resolved) => `${k}:${resolved}`)
           }
@@ -266,7 +380,7 @@ function formatValueMaybe(value: any, verb: string, flags = ''): MaybeString {
       if (flags.includes('#') && hasGoString(value)) {
         return toMaybeString(value.GoString())
       }
-      return defaultFormatMaybe(value)
+      return defaultFormatMaybe(value, flags)
     case 'w':
       return defaultFormatMaybe(value)
     case 's':

--- a/gs/reflect/type.ts
+++ b/gs/reflect/type.ts
@@ -180,10 +180,6 @@ export const UnsafePointer: Kind = 26
 
 const pointerAddressStride = 0x100000000
 const pointerAddresses = new WeakMap<object, number>()
-const fieldPointerAddresses = new WeakMap<
-  object,
-  globalThis.Map<string, number>
->()
 let nextPointerAddress = 1
 const canonicalTypes = new globalThis.Map<string, Type>()
 const constructingRegisteredTypes = new globalThis.Map<string, Type>()
@@ -194,21 +190,6 @@ function pointerAddress(value: object): number {
     address = nextPointerAddress * pointerAddressStride
     nextPointerAddress++
     pointerAddresses.set(value, address)
-  }
-  return address
-}
-
-function fieldPointerAddress(target: object, key: string): number {
-  let addresses = fieldPointerAddresses.get(target)
-  if (addresses === undefined) {
-    addresses = new globalThis.Map<string, number>()
-    fieldPointerAddresses.set(target, addresses)
-  }
-  let address = addresses.get(key)
-  if (address === undefined) {
-    address = nextPointerAddress * pointerAddressStride
-    nextPointerAddress++
-    addresses.set(key, address)
   }
   return address
 }
@@ -583,6 +564,12 @@ export class Value {
   }
 
   private storeValue(value: ReflectValue): void {
+    if (this.Kind() === Struct) {
+      const target = this.currentValue()
+      $.assignStruct(target, value, typeInfoFromReflectType(this._type))
+      this._value = target
+      return
+    }
     this._value = value
     if (this._parentVarRef) {
       this._parentVarRef.value = value
@@ -864,7 +851,8 @@ export class Value {
       throw new Error('reflect: struct field index out of range')
     }
 
-    const parentObj = this._value as Record<string, any>
+    const structValue = this.currentValue() as Record<string, any>
+    const parentObj = structValue._fields ?? structValue
     let fieldVal = parentObj[fieldKey]
     if (fieldVal === undefined) {
       fieldVal = null
@@ -947,11 +935,7 @@ export class Value {
         target,
         key as keyof typeof target,
       ) as $.VarRef<ReflectValue>
-      return {
-        __goOwnedPointer: true,
-        __goAddress: () => fieldPointerAddress(target, key),
-        __goRef: () => ref,
-      }
+      return $.ownedPointerFromRef(ref)!
     }
     if (this._parentVarRef?.__goPointer) {
       return this._parentVarRef

--- a/tests/tests/blank_struct_fields/blank_struct_fields.gs.ts
+++ b/tests/tests/blank_struct_fields/blank_struct_fields.gs.ts
@@ -11,16 +11,16 @@ export class padded {
 	public declare _blank2: Uint8Array
 
 	public _fields: {
-		_blank0: $.VarRef<Uint8Array>
-		Value: $.VarRef<number>
-		_blank2: $.VarRef<Uint8Array>
+		_blank0: Uint8Array
+		Value: number
+		_blank2: Uint8Array
 	}
 
 	constructor(init?: Partial<{_blank0?: Uint8Array, Value?: number, _blank2?: Uint8Array}>) {
 		this._fields = {
-			_blank0: $.varRef(init?._blank0 !== undefined ? $.cloneArrayValue(init._blank0, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 2)) : new Uint8Array(2)),
-			Value: $.varRef(init?.Value ?? (0 as number)),
-			_blank2: $.varRef(init?._blank2 !== undefined ? $.cloneArrayValue(init._blank2, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 3)) : new Uint8Array(3))
+			_blank0: init?._blank0 !== undefined ? $.cloneArrayValue(init._blank0, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 2)) : new Uint8Array(2),
+			Value: init?.Value ?? (0 as number),
+			_blank2: init?._blank2 !== undefined ? $.cloneArrayValue(init._blank2, /* @__PURE__ */ $.arrayType(/* @__PURE__ */ $.basicType("uint8"), 3)) : new Uint8Array(3)
 		}
 	}
 

--- a/tests/tests/cross_file_varref_struct_field/info.gs.ts
+++ b/tests/tests/cross_file_varref_struct_field/info.gs.ts
@@ -4,39 +4,28 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export class floatInfo {
-	public get mantbits(): number {
-		return this._fields.mantbits.value
-	}
-	public set mantbits(value: number) {
-		this._fields.mantbits.value = value
-	}
+	public declare mantbits: number
 
-	public get expbits(): number {
-		return this._fields.expbits.value
-	}
-	public set expbits(value: number) {
-		this._fields.expbits.value = value
-	}
+	public declare expbits: number
 
 	public _fields: {
-		mantbits: $.VarRef<number>
-		expbits: $.VarRef<number>
+		mantbits: number
+		expbits: number
 	}
 
 	constructor(init?: Partial<{mantbits?: number, expbits?: number}>) {
 		this._fields = {
-			mantbits: $.varRef(init?.mantbits ?? (0 as number)),
-			expbits: $.varRef(init?.expbits ?? (0 as number))
+			mantbits: init?.mantbits ?? (0 as number),
+			expbits: init?.expbits ?? (0 as number)
 		}
 	}
 
 	public clone(): floatInfo {
-		const cloned = new floatInfo()
-		cloned._fields = {
-			mantbits: $.varRef(this._fields.mantbits.value),
-			expbits: $.varRef(this._fields.expbits.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new floatInfo(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["mantbits", "expbits"])
 	}
 
 	static __typeInfo = $.registerStructType(
@@ -51,7 +40,7 @@ export class floatInfo {
 export let info: $.VarRef<floatInfo> = $.varRef($.markAsStructValue(new floatInfo({mantbits: 52, expbits: 11})))
 
 export function __goscript_set_info(__goscriptValue: floatInfo): void {
-	info.value = __goscriptValue
+	$.assignStruct(info.value, __goscriptValue)
 }
 
 export function infoPtr(): floatInfo | $.VarRef<floatInfo> | null {

--- a/tests/tests/fmt_struct_values/expected.log
+++ b/tests/tests/fmt_struct_values/expected.log
@@ -1,0 +1,13 @@
+{3 hello {true}}
+{Count:3 name:hello Inner:{Ready:true}}
+&{3 hello {true}}
+&{Count:3 name:hello Inner:{Ready:true}}
+&{3 hello {true}}
+main.Record{Count:3, name:"hello", Inner:main.Inner{Ready:true}}
+&main.Record{Count:3, name:"hello", Inner:main.Inner{Ready:true}}
+{4}
+{Count:4}
+&{4}
+&{Count:4}
+&{Value:<scalar> Next:<self> Dynamic:<self>}
+level=warning msg="waiting for controller Execute to return" controller="&{3 hello {true}}"

--- a/tests/tests/fmt_struct_values/fmt_struct_values.go
+++ b/tests/tests/fmt_struct_values/fmt_struct_values.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Inner supplies a nested value field for formatting.
+type Inner struct {
+	// Ready is included even when it is false.
+	Ready bool
+}
+
+// Record combines named, unexported, and nested fields.
+type Record struct {
+	// Count is the numeric field.
+	Count int
+	// name is visible to formatting despite being unexported.
+	name string
+	// Inner is a nested value.
+	Inner Inner
+}
+
+// Pointers retains scalar and recursive references for formatting.
+type Pointers struct {
+	// Value points to a scalar, which formats as an address.
+	Value *int
+	// Next can point back to this record.
+	Next *Pointers
+	// Dynamic holds a pointer behind an interface.
+	Dynamic any
+}
+
+// main compares generated value and pointer formatting with native Go.
+func main() {
+	value := Record{Count: 3, name: "hello", Inner: Inner{Ready: true}}
+	println(fmt.Sprintf("%v", value))
+	println(fmt.Sprintf("%+v", value))
+	println(fmt.Sprintf("%v", &value))
+	println(fmt.Sprintf("%+v", &value))
+	println(fmt.Sprint(&value))
+	println(fmt.Sprintf("%#v", value))
+	println(fmt.Sprintf("%#v", &value))
+
+	anonymous := struct{ Count int }{Count: 4}
+	println(fmt.Sprintf("%v", anonymous))
+	println(fmt.Sprintf("%+v", anonymous))
+	println(fmt.Sprintf("%v", &anonymous))
+	println(fmt.Sprintf("%+v", &anonymous))
+
+	// Addresses differ across runtimes; their identity and surrounding text agree.
+	count := 7
+	pointers := Pointers{Value: &count}
+	pointers.Next = &pointers
+	pointers.Dynamic = &pointers
+	text := fmt.Sprintf("%+v", &pointers)
+	text = strings.ReplaceAll(text, fmt.Sprintf("%p", &count), "<scalar>")
+	text = strings.ReplaceAll(text, fmt.Sprintf("%p", &pointers), "<self>")
+	println(text)
+
+	// Exercise the same log field formatting used by controller shutdown warnings.
+	var output bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&output)
+	logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableTimestamp: true})
+	logger.WithField("controller", &value).Warn("waiting for controller Execute to return")
+	println(strings.TrimSpace(output.String()))
+}

--- a/tests/tests/fmt_struct_values/fmt_struct_values.gs.ts
+++ b/tests/tests/fmt_struct_values/fmt_struct_values.gs.ts
@@ -1,0 +1,170 @@
+// Generated file based on fmt_struct_values.go
+// Updated when compliance tests are re-run, DO NOT EDIT!
+
+import * as $ from "@goscript/builtin/index.js"
+
+import * as bytes from "@goscript/bytes/index.js"
+
+import * as fmt from "@goscript/fmt/index.js"
+
+import * as strings from "@goscript/strings/index.js"
+
+import * as logrus from "@goscript/github.com/sirupsen/logrus/index.js"
+
+import type * as io from "@goscript/io/index.js"
+import "@goscript/bytes/index.js"
+import "@goscript/fmt/index.js"
+import "@goscript/strings/index.js"
+import "@goscript/github.com/sirupsen/logrus/index.js"
+
+export class Inner {
+	// Ready is included even when it is false.
+	public declare Ready: boolean
+
+	public _fields: {
+		Ready: boolean
+	}
+
+	constructor(init?: Partial<{Ready?: boolean}>) {
+		this._fields = {
+			Ready: init?.Ready ?? (false as boolean)
+		}
+	}
+
+	public clone(): Inner {
+		return $.markAsStructValue(new Inner(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["Ready"])
+	}
+
+	static __typeInfo = $.registerStructType(
+		"main.Inner",
+		() => new Inner(),
+		() => [],
+		Inner,
+		() => [/* @__PURE__ */ $.structField("Ready", /* @__PURE__ */ $.basicType("bool"), [0], 0, true)]
+	)
+}
+
+export class Record {
+	// Count is the numeric field.
+	public declare Count: number
+
+	// name is visible to formatting despite being unexported.
+	public declare name: string
+
+	// Inner is a nested value.
+	public declare Inner: Inner
+
+	public _fields: {
+		Count: number
+		name: string
+		Inner: Inner
+	}
+
+	constructor(init?: Partial<{Count?: number, name?: string, Inner?: Inner}>) {
+		this._fields = {
+			Count: init?.Count ?? (0 as number),
+			name: init?.name ?? ("" as string),
+			Inner: init?.Inner ? $.markAsStructValue($.cloneStructValue(init.Inner)) : $.markAsStructValue(new Inner())
+		}
+	}
+
+	public clone(): Record {
+		return $.markAsStructValue(new Record(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["Count", "name", "Inner"])
+	}
+
+	static __typeInfo = $.registerStructType(
+		"main.Record",
+		() => new Record(),
+		() => [],
+		Record,
+		() => [/* @__PURE__ */ $.structField("Count", /* @__PURE__ */ $.basicType("int"), [0], 0, true), /* @__PURE__ */ $.structField("name", /* @__PURE__ */ $.basicType("string"), [1], 8, false, { pkgPath: "github.com/s4wave/goscript/tests/tests/fmt_struct_values" }), /* @__PURE__ */ $.structField("Inner", "main.Inner", [2], 24, true)]
+	)
+}
+
+export class Pointers {
+	// Value points to a scalar, which formats as an address.
+	public declare Value: $.VarRef<number> | null
+
+	// Next can point back to this record.
+	public declare Next: Pointers | $.VarRef<Pointers> | null
+
+	// Dynamic holds a pointer behind an interface.
+	public declare Dynamic: any
+
+	public _fields: {
+		Value: $.VarRef<number> | null
+		Next: Pointers | $.VarRef<Pointers> | null
+		Dynamic: any
+	}
+
+	constructor(init?: Partial<{Value?: $.VarRef<number> | null, Next?: Pointers | $.VarRef<Pointers> | null, Dynamic?: any}>) {
+		this._fields = {
+			Value: init?.Value ?? (null! as $.VarRef<number> | null),
+			Next: init?.Next ?? (null! as Pointers | $.VarRef<Pointers> | null),
+			Dynamic: init?.Dynamic ?? (null! as any)
+		}
+	}
+
+	public clone(): Pointers {
+		return $.markAsStructValue(new Pointers(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["Value", "Next", "Dynamic"])
+	}
+
+	static __typeInfo = $.registerStructType(
+		"main.Pointers",
+		() => new Pointers(),
+		() => [],
+		Pointers,
+		() => [/* @__PURE__ */ $.structField("Value", /* @__PURE__ */ $.pointerType(/* @__PURE__ */ $.basicType("int")), [0], 0, true), /* @__PURE__ */ $.structField("Next", /* @__PURE__ */ $.pointerType("main.Pointers"), [1], 8, true), /* @__PURE__ */ $.structField("Dynamic", { kind: $.TypeKind.Interface, methods: [] }, [2], 16, true)]
+	)
+}
+
+export async function main(): globalThis.Promise<void> {
+	let value = $.varRef($.markAsStructValue(new Record({Count: 3, name: "hello", Inner: $.markAsStructValue(new Inner({Ready: true}))})))
+	await $.println(await fmt.Sprintf("%v", $.interfaceValue($.markAsStructValue($.cloneStructValue(value.value)), "main.Record", "main.Record")))
+	await $.println(await fmt.Sprintf("%+v", $.interfaceValue($.markAsStructValue($.cloneStructValue(value.value)), "main.Record", "main.Record")))
+	await $.println(await fmt.Sprintf("%v", $.interfaceValue(value, "*main.Record", /* @__PURE__ */ $.pointerType("main.Record"))))
+	await $.println(await fmt.Sprintf("%+v", $.interfaceValue(value, "*main.Record", /* @__PURE__ */ $.pointerType("main.Record"))))
+	await $.println(await fmt.Sprint($.interfaceValue(value, "*main.Record", /* @__PURE__ */ $.pointerType("main.Record"))))
+	await $.println(await fmt.Sprintf("%#v", $.interfaceValue($.markAsStructValue($.cloneStructValue(value.value)), "main.Record", "main.Record")))
+	await $.println(await fmt.Sprintf("%#v", $.interfaceValue(value, "*main.Record", /* @__PURE__ */ $.pointerType("main.Record"))))
+
+	let anonymous = $.varRef({Count: 4})
+	await $.println(await fmt.Sprintf("%v", anonymous.value))
+	await $.println(await fmt.Sprintf("%+v", anonymous.value))
+	await $.println(await fmt.Sprintf("%v", $.interfaceValue(anonymous, "*struct{Count int}", /* @__PURE__ */ $.pointerType({ kind: $.TypeKind.Struct, methods: [], fields: [/* @__PURE__ */ $.structField("Count", /* @__PURE__ */ $.basicType("int"), [0], 0, true)] }))))
+	await $.println(await fmt.Sprintf("%+v", $.interfaceValue(anonymous, "*struct{Count int}", /* @__PURE__ */ $.pointerType({ kind: $.TypeKind.Struct, methods: [], fields: [/* @__PURE__ */ $.structField("Count", /* @__PURE__ */ $.basicType("int"), [0], 0, true)] }))))
+
+	// Addresses differ across runtimes; their identity and surrounding text agree.
+	let count = $.varRef(7)
+	let pointers = $.varRef($.markAsStructValue(new Pointers({Value: count})))
+	pointers.value.Next = pointers
+	pointers.value.Dynamic = $.interfaceValue(pointers, "*main.Pointers", /* @__PURE__ */ $.pointerType("main.Pointers"))
+	let text = await fmt.Sprintf("%+v", $.interfaceValue(pointers, "*main.Pointers", /* @__PURE__ */ $.pointerType("main.Pointers")))
+	text = strings.ReplaceAll(text, await fmt.Sprintf("%p", $.interfaceValue(count, "*int", /* @__PURE__ */ $.pointerType(/* @__PURE__ */ $.basicType("int")))), "<scalar>")
+	text = strings.ReplaceAll(text, await fmt.Sprintf("%p", $.interfaceValue(pointers, "*main.Pointers", /* @__PURE__ */ $.pointerType("main.Pointers"))), "<self>")
+	await $.println(text)
+
+	// Exercise the same log field formatting used by controller shutdown warnings.
+	let output: $.VarRef<bytes.Buffer> = $.varRef($.markAsStructValue(new bytes.Buffer()))
+	let logger: logrus.Logger | $.VarRef<logrus.Logger> | null = logrus.New()
+	await logrus.Logger.prototype.SetOutput.call(logger, $.interfaceValue<io.Writer | null>(output, "*bytes.Buffer", /* @__PURE__ */ $.pointerType("bytes.Buffer")))
+	await logrus.Logger.prototype.SetFormatter.call(logger, $.interfaceValue<logrus.Formatter | null>(new logrus.TextFormatter({DisableColors: true, DisableTimestamp: true}), "*logrus.TextFormatter", /* @__PURE__ */ $.pointerType("logrus.TextFormatter")))
+	await logrus.Entry.prototype.Warn.call(await logrus.Logger.prototype.WithField.call(logger, "controller", $.interfaceValue(value, "*main.Record", /* @__PURE__ */ $.pointerType("main.Record"))), $.arrayToSlice<any>(["waiting for controller Execute to return"]))
+	await $.println(strings.TrimSpace(output.value.String()))
+}
+
+if ($.isMainScript(import.meta)) {
+	await main()
+}

--- a/tests/tests/fmt_struct_values/index.ts
+++ b/tests/tests/fmt_struct_values/index.ts
@@ -1,0 +1,1 @@
+export { Inner, Pointers, Record } from "./fmt_struct_values.gs.ts"

--- a/tests/tests/fmt_struct_values/tsconfig.json
+++ b/tests/tests/fmt_struct_values/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "*": [
+        "./*"
+      ],
+      "@goscript/*": [
+        "../../../tests/tests/fmt_struct_values/run/output/@goscript/*",
+        "../../../gs/*",
+        "../../../tests/deps/*"
+      ],
+      "@goscript/github.com/s4wave/goscript/tests/tests/fmt_struct_values/*": [
+        "./*"
+      ]
+    }
+  },
+  "extends": "../../../tests/tsconfig.base.json",
+  "include": [
+    "fmt_struct_values.gs.ts",
+    "index.ts"
+  ]
+}

--- a/tests/tests/generic_constrained_slice_clone/generic_constrained_slice_clone.gs.ts
+++ b/tests/tests/generic_constrained_slice_clone/generic_constrained_slice_clone.gs.ts
@@ -17,12 +17,12 @@ export class item {
 	public declare value: string
 
 	public _fields: {
-		value: $.VarRef<string>
+		value: string
 	}
 
 	constructor(init?: Partial<{value?: string}>) {
 		this._fields = {
-			value: $.varRef(init?.value ?? ("" as string))
+			value: init?.value ?? ("" as string)
 		}
 	}
 

--- a/tests/tests/package_import_io_fs_readdir_varref/package_import_io_fs_readdir_varref.gs.ts
+++ b/tests/tests/package_import_io_fs_readdir_varref/package_import_io_fs_readdir_varref.gs.ts
@@ -10,34 +10,29 @@ import "@goscript/io/fs/index.js"
 import "@goscript/testing/fstest/index.js"
 
 export class openOnlyFS {
-	public get fsys(): fstest.MapFS {
-		return this._fields.fsys.value
-	}
-	public set fsys(value: fstest.MapFS) {
-		this._fields.fsys.value = value
-	}
+	public declare fsys: fstest.MapFS
 
 	public _fields: {
-		fsys: $.VarRef<fstest.MapFS>
+		fsys: fstest.MapFS
 	}
 
 	constructor(init?: Partial<{fsys?: fstest.MapFS}>) {
 		this._fields = {
-			fsys: $.varRef(init?.fsys ?? (null! as fstest.MapFS))
+			fsys: init?.fsys ?? (null! as fstest.MapFS)
 		}
 	}
 
 	public clone(): openOnlyFS {
-		const cloned = new openOnlyFS()
-		cloned._fields = {
-			fsys: $.varRef(this._fields.fsys.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new openOnlyFS(this))
 	}
 
 	public async Open(name: string): globalThis.Promise<[fs.File | null, $.GoError]> {
 		const o = this
 		return fstest.MapFS_Open(o.fsys, name)
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["fsys"])
 	}
 
 	static __typeInfo = $.registerStructType(

--- a/tests/tests/shadowed_varref_pointer_receiver/shadowed_varref_pointer_receiver.gs.ts
+++ b/tests/tests/shadowed_varref_pointer_receiver/shadowed_varref_pointer_receiver.gs.ts
@@ -4,29 +4,20 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export class locked {
-	public get value(): number {
-		return this._fields.value.value
-	}
-	public set value(value: number) {
-		this._fields.value.value = value
-	}
+	public declare value: number
 
 	public _fields: {
-		value: $.VarRef<number>
+		value: number
 	}
 
 	constructor(init?: Partial<{value?: number}>) {
 		this._fields = {
-			value: $.varRef(init?.value ?? (0 as number))
+			value: init?.value ?? (0 as number)
 		}
 	}
 
 	public clone(): locked {
-		const cloned = new locked()
-		cloned._fields = {
-			value: $.varRef(this._fields.value.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new locked(this))
 	}
 
 	public Inc(): void {
@@ -37,6 +28,10 @@ export class locked {
 	public Value(): number {
 		const l: locked | $.VarRef<locked> | null = this
 		return $.pointerValue<locked>(l).value
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["value"])
 	}
 
 	static __typeInfo = $.registerStructType(

--- a/tests/tests/struct_method_clone_collision/struct_method_clone_collision.gs.ts
+++ b/tests/tests/struct_method_clone_collision/struct_method_clone_collision.gs.ts
@@ -7,12 +7,12 @@ export class Box {
 	public declare Value: number
 
 	public _fields: {
-		Value: $.VarRef<number>
+		Value: number
 	}
 
 	constructor(init?: Partial<{Value?: number}>) {
 		this._fields = {
-			Value: $.varRef(init?.Value ?? (0 as number))
+			Value: init?.Value ?? (0 as number)
 		}
 	}
 

--- a/tests/tests/struct_pointer_interface_fields/struct_pointer_interface_fields.gs.ts
+++ b/tests/tests/struct_pointer_interface_fields/struct_pointer_interface_fields.gs.ts
@@ -14,39 +14,28 @@ $.registerInterfaceType(
 );
 
 export class MyStruct {
-	public get PointerField(): $.VarRef<number> | null {
-		return this._fields.PointerField.value
-	}
-	public set PointerField(value: $.VarRef<number> | null) {
-		this._fields.PointerField.value = value
-	}
+	public declare PointerField: $.VarRef<number> | null
 
-	public get interfaceField(): MyInterface | null {
-		return this._fields.interfaceField.value
-	}
-	public set interfaceField(value: MyInterface | null) {
-		this._fields.interfaceField.value = value
-	}
+	public declare interfaceField: MyInterface | null
 
 	public _fields: {
-		PointerField: $.VarRef<$.VarRef<number> | null>
-		interfaceField: $.VarRef<MyInterface | null>
+		PointerField: $.VarRef<number> | null
+		interfaceField: MyInterface | null
 	}
 
 	constructor(init?: Partial<{PointerField?: $.VarRef<number> | null, interfaceField?: MyInterface | null}>) {
 		this._fields = {
-			PointerField: $.varRef(init?.PointerField ?? (null! as $.VarRef<number> | null)),
-			interfaceField: $.varRef(init?.interfaceField ?? (null! as MyInterface | null))
+			PointerField: init?.PointerField ?? (null! as $.VarRef<number> | null),
+			interfaceField: init?.interfaceField ?? (null! as MyInterface | null)
 		}
 	}
 
 	public clone(): MyStruct {
-		const cloned = new MyStruct()
-		cloned._fields = {
-			PointerField: $.varRef(this._fields.PointerField.value),
-			interfaceField: $.varRef(this._fields.interfaceField.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new MyStruct(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["PointerField", "interfaceField"])
 	}
 
 	static __typeInfo = $.registerStructType(
@@ -54,7 +43,7 @@ export class MyStruct {
 		() => new MyStruct(),
 		() => [],
 		MyStruct,
-		() => [{ name: "PointerField", key: "PointerField", type: { kind: $.TypeKind.Pointer, elemType: /* @__PURE__ */ $.basicType("int") } }, { name: "interfaceField", key: "interfaceField", type: "main.MyInterface" }]
+		() => [{ name: "PointerField", key: "PointerField", type: /* @__PURE__ */ $.pointerType(/* @__PURE__ */ $.basicType("int")) }, { name: "interfaceField", key: "interfaceField", type: "main.MyInterface" }]
 	)
 }
 

--- a/tests/tests/type_switch_varref_suffix/type_switch_varref_suffix.gs.ts
+++ b/tests/tests/type_switch_varref_suffix/type_switch_varref_suffix.gs.ts
@@ -14,34 +14,29 @@ $.registerInterfaceType(
 );
 
 export class branch {
-	public get n(): number {
-		return this._fields.n.value
-	}
-	public set n(value: number) {
-		this._fields.n.value = value
-	}
+	public declare n: number
 
 	public _fields: {
-		n: $.VarRef<number>
+		n: number
 	}
 
 	constructor(init?: Partial<{n?: number}>) {
 		this._fields = {
-			n: $.varRef(init?.n ?? (0 as number))
+			n: init?.n ?? (0 as number)
 		}
 	}
 
 	public clone(): branch {
-		const cloned = new branch()
-		cloned._fields = {
-			n: $.varRef(this._fields.n.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new branch(this))
 	}
 
 	public value(): number {
 		const b: branch | $.VarRef<branch> | null = this
 		return $.pointerValue<branch>(b).n
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["n"])
 	}
 
 	static __typeInfo = $.registerStructType(
@@ -58,13 +53,13 @@ export function accept(b: branch | $.VarRef<branch> | null): number {
 }
 
 export async function main(): globalThis.Promise<void> {
-	let v: node | null = $.interfaceValue<node | null>(new branch({n: 3}), "*main.branch", { kind: $.TypeKind.Pointer, elemType: "main.branch" })
+	let v: node | null = $.interfaceValue<node | null>(new branch({n: 3}), "*main.branch", /* @__PURE__ */ $.pointerType("main.branch"))
 	{
 		const __goscriptTypeSwitchValue = v
 		switch (true) {
-			case $.typeAssert<branch | $.VarRef<branch> | null>(__goscriptTypeSwitchValue, { kind: $.TypeKind.Pointer, elemType: "main.branch" }).ok:
+			case $.typeAssert<branch | $.VarRef<branch> | null>(__goscriptTypeSwitchValue, /* @__PURE__ */ $.pointerType("main.branch")).ok:
 				{
-					let e: branch | $.VarRef<branch> | null = $.typeAssert<branch | $.VarRef<branch> | null>(__goscriptTypeSwitchValue, { kind: $.TypeKind.Pointer, elemType: "main.branch" }).value
+					let e: branch | $.VarRef<branch> | null = $.typeAssert<branch | $.VarRef<branch> | null>(__goscriptTypeSwitchValue, /* @__PURE__ */ $.pointerType("main.branch")).value
 					let imprecise = $.varRef(0)
 					let ptr = imprecise
 					ptr!.value = 4

--- a/tests/tests/varref_composite_lit/varref_composite_lit.gs.ts
+++ b/tests/tests/varref_composite_lit/varref_composite_lit.gs.ts
@@ -4,34 +4,29 @@
 import * as $ from "@goscript/builtin/index.js"
 
 export class MockInode {
-	public get Value(): number {
-		return this._fields.Value.value
-	}
-	public set Value(value: number) {
-		this._fields.Value.value = value
-	}
+	public declare Value: number
 
 	public _fields: {
-		Value: $.VarRef<number>
+		Value: number
 	}
 
 	constructor(init?: Partial<{Value?: number}>) {
 		this._fields = {
-			Value: $.varRef(init?.Value ?? (0 as number))
+			Value: init?.Value ?? (0 as number)
 		}
 	}
 
 	public clone(): MockInode {
-		const cloned = new MockInode()
-		cloned._fields = {
-			Value: $.varRef(this._fields.Value.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new MockInode(this))
 	}
 
 	public getValue(): number {
 		const m: MockInode | $.VarRef<MockInode> | null = this
 		return $.pointerValue<MockInode>(m).Value
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["Value"])
 	}
 
 	static __typeInfo = $.registerStructType(

--- a/tests/tests/varref_struct/expected.log
+++ b/tests/tests/varref_struct/expected.log
@@ -1,2 +1,12 @@
 ptrToVal.MyInt: 10
 myIntVal: 10
+field after assignment: 30 true
+write through field: 40 40
+keyword field: 6 true
+nested: 50 60 true 1
+nested identity: true true true
+tuple: 70 80
+parallel: 80 70
+global: 90
+reflect: 100 true
+reflect address: true

--- a/tests/tests/varref_struct/index.ts
+++ b/tests/tests/varref_struct/index.ts
@@ -1,1 +1,1 @@
-export { MyStruct } from "./varref_struct.gs.ts"
+export { MyStruct, Outer } from "./varref_struct.gs.ts"

--- a/tests/tests/varref_struct/varref_struct.go
+++ b/tests/tests/varref_struct/varref_struct.go
@@ -1,9 +1,32 @@
 package main
 
+import "reflect"
+
+// MyStruct supplies an addressable value field.
 type MyStruct struct {
+	// MyInt is shared through pointers to this storage.
 	MyInt int
 }
 
+// Outer combines copied aggregate storage and shared pointer fields.
+type Outer struct {
+	// Child is copied in place during assignment.
+	Child MyStruct
+	// Items retains the addresses of array elements.
+	Items [2]MyStruct
+	// Ptr is replaced rather than copied through its pointee.
+	Ptr *MyStruct
+}
+
+// global exercises package-variable setter assignment.
+var global MyStruct
+
+// pair returns two independent values for tuple assignment.
+func pair() (MyStruct, MyStruct) {
+	return MyStruct{MyInt: 70}, MyStruct{MyInt: 80}
+}
+
+// main checks variable and field identity across assignment paths.
 func main() {
 	// 'val' is a value type, but its address is taken, so it should be varrefed in TS.
 	val := MyStruct{MyInt: 10}
@@ -15,4 +38,43 @@ func main() {
 	// Accessing pointer value, should use .value
 	myIntVal := ptrToVal.MyInt
 	println("myIntVal:", myIntVal)
+
+	// Field pointers retain their storage identity across whole-value assignment.
+	field := &val.MyInt
+	val = MyStruct{MyInt: 30}
+	println("field after assignment:", *field, field == &val.MyInt)
+	*field = 40
+	println("write through field:", val.MyInt, ptrToVal.MyInt)
+
+	// TypeScript keywords use the same storage key for reads and addresses.
+	keywords := struct{ catch int }{catch: 5}
+	keyword := &keywords.catch
+	*keyword = 6
+	println("keyword field:", keywords.catch, keyword == &keywords.catch)
+
+	// Nested values keep their storage while pointer fields change referents.
+	first := &MyStruct{MyInt: 1}
+	second := &MyStruct{MyInt: 2}
+	outer := Outer{Ptr: first}
+	child := &outer.Child.MyInt
+	item := &outer.Items[0].MyInt
+	ptrField := &outer.Ptr
+	outer = Outer{Child: MyStruct{MyInt: 50}, Items: [2]MyStruct{{MyInt: 60}}, Ptr: second}
+	println("nested:", *child, *item, *ptrField == second, first.MyInt)
+	println("nested identity:", child == &outer.Child.MyInt, item == &outer.Items[0].MyInt, ptrField == &outer.Ptr)
+
+	// Both tuple and parallel assignments update existing variable storage.
+	val, global = pair()
+	println("tuple:", *field, global.MyInt)
+	globalField := &global.MyInt
+	val, global = global, val
+	println("parallel:", *field, *globalField)
+	global = MyStruct{MyInt: 90}
+	println("global:", *globalField)
+
+	// Reflection writes through the same aggregate storage as generated assignment.
+	reflect.ValueOf(&val).Elem().Set(reflect.ValueOf(MyStruct{MyInt: 100}))
+	println("reflect:", *field, field == &val.MyInt)
+	reflected := reflect.ValueOf(&val).Elem().FieldByName("MyInt").Addr().Interface().(*int)
+	println("reflect address:", reflected == field)
 }

--- a/tests/tests/varref_struct/varref_struct.gs.ts
+++ b/tests/tests/varref_struct/varref_struct.gs.ts
@@ -3,25 +3,25 @@
 
 import * as $ from "@goscript/builtin/index.js"
 
+import * as reflect from "@goscript/reflect/index.js"
+import "@goscript/reflect/index.js"
+
 export class MyStruct {
+	// MyInt is shared through pointers to this storage.
 	public declare MyInt: number
 
 	public _fields: {
-		MyInt: $.VarRef<number>
+		MyInt: number
 	}
 
 	constructor(init?: Partial<{MyInt?: number}>) {
 		this._fields = {
-			MyInt: $.varRef(init?.MyInt ?? (0 as number))
+			MyInt: init?.MyInt ?? (0 as number)
 		}
 	}
 
 	public clone(): MyStruct {
-		const cloned = new MyStruct()
-		cloned._fields = {
-			MyInt: $.varRef(this._fields.MyInt.value)
-		}
-		return $.markAsStructValue(cloned)
+		return $.markAsStructValue(new MyStruct(this))
 	}
 
 	static {
@@ -33,8 +33,59 @@ export class MyStruct {
 		() => new MyStruct(),
 		() => [],
 		MyStruct,
-		() => [{ name: "MyInt", key: "MyInt", type: /* @__PURE__ */ $.basicType("int") }]
+		() => [/* @__PURE__ */ $.structField("MyInt", /* @__PURE__ */ $.basicType("int"), [0], 0, true)]
 	)
+}
+
+export class Outer {
+	// Child is copied in place during assignment.
+	public declare Child: MyStruct
+
+	// Items retains the addresses of array elements.
+	public declare Items: MyStruct[]
+
+	// Ptr is replaced rather than copied through its pointee.
+	public declare Ptr: MyStruct | $.VarRef<MyStruct> | null
+
+	public _fields: {
+		Child: MyStruct
+		Items: MyStruct[]
+		Ptr: MyStruct | $.VarRef<MyStruct> | null
+	}
+
+	constructor(init?: Partial<{Child?: MyStruct, Items?: MyStruct[], Ptr?: MyStruct | $.VarRef<MyStruct> | null}>) {
+		this._fields = {
+			Child: init?.Child ? $.markAsStructValue($.cloneStructValue(init.Child)) : $.markAsStructValue(new MyStruct()),
+			Items: init?.Items !== undefined ? $.cloneArrayValue(init.Items, /* @__PURE__ */ $.arrayType("main.MyStruct", 2)) : Array.from({ length: 2 }, () => $.markAsStructValue(new MyStruct())),
+			Ptr: init?.Ptr ?? (null! as MyStruct | $.VarRef<MyStruct> | null)
+		}
+	}
+
+	public clone(): Outer {
+		return $.markAsStructValue(new Outer(this))
+	}
+
+	static {
+		$.bindStructFields(this.prototype, ["Child", "Items", "Ptr"])
+	}
+
+	static __typeInfo = $.registerStructType(
+		"main.Outer",
+		() => new Outer(),
+		() => [],
+		Outer,
+		() => [/* @__PURE__ */ $.structField("Child", "main.MyStruct", [0], 0, true), /* @__PURE__ */ $.structField("Items", /* @__PURE__ */ $.arrayType("main.MyStruct", 2), [1], 8, true), /* @__PURE__ */ $.structField("Ptr", /* @__PURE__ */ $.pointerType("main.MyStruct"), [2], 24, true)]
+	)
+}
+
+export let global: MyStruct = $.markAsStructValue(new MyStruct())
+
+export function __goscript_set_global(__goscriptValue: MyStruct): void {
+	$.assignStruct(global, __goscriptValue)
+}
+
+export function pair(): [MyStruct, MyStruct] {
+	return [$.markAsStructValue(new MyStruct({MyInt: 70})), $.markAsStructValue(new MyStruct({MyInt: 80}))]
 }
 
 export async function main(): globalThis.Promise<void> {
@@ -48,6 +99,50 @@ export async function main(): globalThis.Promise<void> {
 	// Accessing pointer value, should use .value
 	let myIntVal = $.pointerValue<MyStruct>(ptrToVal).MyInt
 	await $.println("myIntVal:", myIntVal)
+
+	// Field pointers retain their storage identity across whole-value assignment.
+	let field = $.fieldRef(val.value._fields, "MyInt")
+	$.assignStruct(val.value, $.markAsStructValue(new MyStruct({MyInt: 30})))
+	await $.println("field after assignment:", $.pointerValue<number>(field), $.pointerEqual(field, $.fieldRef(val.value._fields, "MyInt")))
+	field!.value = 40
+	await $.println("write through field:", val.value.MyInt, $.pointerValue<MyStruct>(ptrToVal).MyInt)
+
+	// TypeScript keywords use the same storage key for reads and addresses.
+	let keywords = {_catch: 5}
+	let keyword = $.fieldRef(keywords, "_catch")
+	keyword!.value = 6
+	await $.println("keyword field:", keywords._catch, $.pointerEqual(keyword, $.fieldRef(keywords, "_catch")))
+
+	// Nested values keep their storage while pointer fields change referents.
+	let first: MyStruct | $.VarRef<MyStruct> | null = new MyStruct({MyInt: 1})
+	let second: MyStruct | $.VarRef<MyStruct> | null = new MyStruct({MyInt: 2})
+	let outer = $.markAsStructValue(new Outer({Ptr: first}))
+	let child = $.fieldRef(outer.Child._fields, "MyInt")
+	let item = $.fieldRef($.arrayIndex(outer.Items, 0)._fields, "MyInt")
+	let ptrField = $.fieldRef(outer._fields, "Ptr")
+	$.assignStruct(outer, $.markAsStructValue(new Outer({Child: $.markAsStructValue(new MyStruct({MyInt: 50})), Items: [$.markAsStructValue(new MyStruct({MyInt: 60})), $.markAsStructValue(new MyStruct())], Ptr: second})))
+	await $.println("nested:", $.pointerValue<number>(child), $.pointerValue<number>(item), $.pointerEqual($.pointerValue<MyStruct | $.VarRef<MyStruct> | null>(ptrField), second), $.pointerValue<MyStruct>(first).MyInt)
+	await $.println("nested identity:", $.pointerEqual(child, $.fieldRef(outer.Child._fields, "MyInt")), $.pointerEqual(item, $.fieldRef($.arrayIndex(outer.Items, 0)._fields, "MyInt")), $.pointerEqual(ptrField, $.fieldRef(outer._fields, "Ptr")))
+
+	// Both tuple and parallel assignments update existing variable storage.
+	let __goscriptTuple0: any = pair()
+	$.assignStruct(val.value, __goscriptTuple0[0])
+	$.assignStruct(global, __goscriptTuple0[1])
+	await $.println("tuple:", $.pointerValue<number>(field), global.MyInt)
+	let globalField = $.fieldRef(global._fields, "MyInt")
+	let __goscriptAssign0_0: MyStruct = $.markAsStructValue($.cloneStructValue(global))
+	let __goscriptAssign0_1: MyStruct = $.markAsStructValue($.cloneStructValue(val.value))
+	$.assignStruct(val.value, __goscriptAssign0_0)
+	$.assignStruct(global, __goscriptAssign0_1)
+	await $.println("parallel:", $.pointerValue<number>(field), $.pointerValue<number>(globalField))
+	$.assignStruct(global, $.markAsStructValue(new MyStruct({MyInt: 90})))
+	await $.println("global:", $.pointerValue<number>(globalField))
+
+	// Reflection writes through the same aggregate storage as generated assignment.
+	$.markAsStructValue($.cloneStructValue($.markAsStructValue($.cloneStructValue(reflect.ValueOf($.interfaceValue(val, "*main.MyStruct", /* @__PURE__ */ $.pointerType("main.MyStruct"))))).Elem())).Set($.markAsStructValue($.cloneStructValue(reflect.ValueOf($.interfaceValue($.markAsStructValue(new MyStruct({MyInt: 100})), "main.MyStruct", "main.MyStruct")))))
+	await $.println("reflect:", $.pointerValue<number>(field), $.pointerEqual(field, $.fieldRef(val.value._fields, "MyInt")))
+	let reflected = $.mustTypeAssert<$.VarRef<number> | null>($.markAsStructValue($.cloneStructValue($.markAsStructValue($.cloneStructValue($.markAsStructValue($.cloneStructValue($.markAsStructValue($.cloneStructValue(reflect.ValueOf($.interfaceValue(val, "*main.MyStruct", /* @__PURE__ */ $.pointerType("main.MyStruct"))))).Elem())).FieldByName("MyInt"))).Addr())).Interface(), /* @__PURE__ */ $.pointerType(/* @__PURE__ */ $.basicType("int")))
+	await $.println("reflect address:", $.pointerEqual(reflected, field))
 }
 
 if ($.isMainScript(import.meta)) {


### PR DESCRIPTION
Preserve held field pointers when named structs are assigned, including nested struct and array storage. Reflection now shares the same assignment operation and canonical field references as generated code.

Format structs using Go field metadata and pointer rules so Logrus fields no longer expose _fields or JavaScript object strings. Preserve the original VarRef design document and describe the current representation separately.

Validated against native Go for field identity, reflection, named and anonymous struct formatting, recursive pointer graphs, and a Logrus warning. Focused compiler and compliance checks, 239 runtime tests, TypeScript checking, and lint pass. Go lint used the declared Go 1.26.4 baseline because the installed linter cannot decode Go 1.27 export data; JavaScript lint retains four existing generated-file warnings.
